### PR TITLE
Testen von weiteren Backend Updates

### DIFF
--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,8 +1,8 @@
-# Backend updaten (Version :VERSION)
+# Testen von weiteren Backend Updates (Version :VERSION)
 
 ## Zusammenfassung der Änderungen
 
-Im [Issue #2443 im Amplify Backend repo](https://github.com/aws-amplify/amplify-category-api/issues/2443) habe ich einen Fehler gemeldet, dass einzelne Datensätze zwar in der DynamoDB Tabelle zu sehen sind, aber die GraphQl Abfragen diese nicht ausspucken. Mir wurde geraten, das Amplify Backend auf eine neue Version zu updaten.
+Im [Issue #2443 im Amplify Backend repo](https://github.com/aws-amplify/amplify-category-api/issues/2443) habe ich einen Fehler gemeldet, dass einzelne Datensätze zwar in der DynamoDB Tabelle zu sehen sind, aber die GraphQl Abfragen diese nicht ausspucken. Mir wurde geraten, das Amplify Backend auf eine neue Version zu updaten. Mir wurde außerdem geraten, "Secondary Indexes" einzurichten, um gezielter Datensätze aus DynamoDB abzurufen. Habe festgestellt, dass das etwas komplizierter ist, da ich hierbei auch das Backend auf die letzte Version upgraden müsste. Die neue Version unterstützt aber keine many-to-many Beziehungen mehr und das würde eine größere Veränderung nach sich ziehen, inklusive des Risikos von Datenverlust.
 
 ## Detailed changes
 
@@ -11,3 +11,7 @@ Im [Issue #2443 im Amplify Backend repo](https://github.com/aws-amplify/amplify-
 #### deps
 
 - trying to fix the AppSync resolvers with a backend update [89fd19d](https://github.com/cabcookie/personal-crm/commit/89fd19d4683ab9b76d89892a8b89857e3371013f)
+
+### Miscellaneous
+
+- added sandbox script [edbd25f](https://github.com/cabcookie/personal-crm/commit/edbd25f8b0c4d03f2cacbb4f51c1782045cedda8)

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "personal-crm",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "personal-crm",
-      "version": "1.2.0",
+      "version": "1.2.1",
       "dependencies": {
         "@aws-amplify/ui-react": "^6.1.2",
         "aws-amplify": "^6.0.16",
@@ -20741,6 +20741,7 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
       "dependencies": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -21668,7 +21669,8 @@
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true
     },
     "node_modules/consola": {
       "version": "3.2.3",
@@ -24798,6 +24800,7 @@
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
       "integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+      "dev": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^4.0.0",
@@ -25873,6 +25876,7 @@
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.1.tgz",
       "integrity": "sha512-5Fytz/IraMjqpwfd34ke28PTVMjZjJG2MPn5t7OE4eUCUNf8BAa7b5WUS9/Qvr6mwOQS7Mk6vdsMno5he+T8Xw==",
+      "dev": true,
       "engines": {
         "node": ">= 4"
       }
@@ -26979,6 +26983,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
       "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+      "dev": true,
       "optionalDependencies": {
         "graceful-fs": "^4.1.6"
       }
@@ -28437,6 +28442,7 @@
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
       "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -28445,6 +28451,7 @@
       "version": "2.1.35",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
       "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
       "dependencies": {
         "mime-db": "1.52.0"
       },
@@ -28501,6 +28508,7 @@
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
       "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
       "dependencies": {
         "brace-expansion": "^1.1.7"
       },
@@ -30366,6 +30374,7 @@
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
       "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -31940,6 +31949,7 @@
       "version": "7.6.0",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
       "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
       "dependencies": {
         "lru-cache": "^6.0.0"
       },
@@ -31954,6 +31964,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
       "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
       "dependencies": {
         "yallist": "^4.0.0"
       },
@@ -31964,7 +31975,8 @@
     "node_modules/semver/node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true
     },
     "node_modules/send": {
       "version": "0.18.0",
@@ -34315,6 +34327,7 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
       "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+      "dev": true,
       "engines": {
         "node": ">= 4.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "next lint",
     "prepare": "node .husky/install.mjs",
     "storybook": "storybook dev -p 6006",
-    "build-storybook": "storybook build"
+    "build-storybook": "storybook build",
+    "sandbox": "npx amplify sandbox --profile impulso"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
## Zusammenfassung der Änderungen

Im [Issue #2443 im Amplify Backend repo](https://github.com/aws-amplify/amplify-category-api/issues/2443) habe ich einen Fehler gemeldet, dass einzelne Datensätze zwar in der DynamoDB Tabelle zu sehen sind, aber die GraphQl Abfragen diese nicht ausspucken. Mir wurde geraten, das Amplify Backend auf eine neue Version zu updaten. Mir wurde außerdem geraten, "Secondary Indexes" einzurichten, um gezielter Datensätze aus DynamoDB abzurufen. Habe festgestellt, dass das etwas komplizierter ist, da ich hierbei auch das Backend auf die letzte Version upgraden müsste. Die neue Version unterstützt aber keine many-to-many Beziehungen mehr und das würde eine größere Veränderung nach sich ziehen, inklusive des Risikos von Datenverlust.

## Detailed changes

### Bug Fixes

#### deps

- trying to fix the AppSync resolvers with a backend update [89fd19d](https://github.com/cabcookie/personal-crm/commit/89fd19d4683ab9b76d89892a8b89857e3371013f)

### Miscellaneous

- added sandbox script [edbd25f](https://github.com/cabcookie/personal-crm/commit/edbd25f8b0c4d03f2cacbb4f51c1782045cedda8)
