### PR TITLE
Fix: Datensätze in der Datenbank dürfen nicht mit einer ID angelegt werden

### DIFF
--- a/api/useDayplans.ts
+++ b/api/useDayplans.ts
@@ -57,7 +57,9 @@ const useDayPlans = (context?: Context) => {
     const updatedDayPlans = [newDayPlan, ...(dayPlans || [])];
     mutate(updatedDayPlans, false);
     const { errors } = await client.models.DayPlan.create({
-      ...newDayPlan,
+      day,
+      dayGoal,
+      done: false,
       context,
     });
     if (errors) handleApiErrors(errors, "Error creating day plan");

--- a/api/useMeetingActivities.ts
+++ b/api/useMeetingActivities.ts
@@ -52,7 +52,6 @@ const useMeetingActivities = ({
     const updated = [...(meetingActivities || []), newActivity];
     mutateMeetingActivities(updated, false);
     const { data, errors } = await client.models.Activity.create({
-      id: activityId,
       meetingActivitiesId: meetingId,
       notes,
     });

--- a/api/useMeetingParticipants.ts
+++ b/api/useMeetingParticipants.ts
@@ -43,7 +43,7 @@ const useMeetingParticipants = (meetingId?: string) => {
     const updated = [...(meetingParticipants || []), newMp];
     mutateMeetingParticipants(updated, false);
     const { data, errors } = await client.models.MeetingParticipant.create({
-      ...newMp,
+      personId,
       meetingId,
     });
     if (errors) handleApiErrors(errors, "Error creating meeting participant");

--- a/api/useMeetings.ts
+++ b/api/useMeetings.ts
@@ -97,7 +97,7 @@ const useMeetings = ({ page = 1, context }: UseMeetingsProps) => {
     const updatedMeetings = [newMeeting, ...(meetings || [])];
     mutateMeetings(updatedMeetings, false);
     const { data, errors } = await client.models.Meeting.create({
-      ...newMeeting,
+      topic,
       meetingOn: newMeeting.meetingOn.toISOString(),
       context,
     });

--- a/api/usePeople.ts
+++ b/api/usePeople.ts
@@ -27,7 +27,7 @@ const usePeople = () => {
     const updated = [...(people || []), newPerson];
     mutatePeople(updated, false);
 
-    const { data, errors } = await client.models.Person.create(newPerson);
+    const { data, errors } = await client.models.Person.create({ name });
     if (errors) handleApiErrors(errors, "Error creating person");
     mutatePeople(updated);
     return data.id;

--- a/api/useProjectActivities.ts
+++ b/api/useProjectActivities.ts
@@ -54,7 +54,7 @@ const useProjectActivities = (projectId?: string) => {
   const createProjectActivity = async (activityId: string, notes?: string) => {
     if (!projectId) return;
     const { data: activity, errors: errorsActivity } =
-      await client.models.Activity.create({ id: activityId, notes });
+      await client.models.Activity.create({ notes });
     if (errorsActivity) {
       handleApiErrors(
         errorsActivity,

--- a/api/useProjects.ts
+++ b/api/useProjects.ts
@@ -38,7 +38,6 @@ const useProjects = (context?: Context) => {
     mutate(updatedProjects, false);
 
     const { data, errors } = await client.models.Projects.create({
-      id: newProject.id,
       project: projectName,
       done: false,
       context,

--- a/api/useTasks.ts
+++ b/api/useTasks.ts
@@ -55,7 +55,8 @@ const useTasks = (dayPlanId: string) => {
         ];
         mutateNonProjectTasks(updatedTasks, false);
         const { errors } = await client.models.NonProjectTask.create({
-          ...newTask,
+          task,
+          done: false,
           dayPlanTasksId: dayPlanId,
         });
         if (errors) handleApiErrors(errors, "Error creating task in day plan");
@@ -67,7 +68,8 @@ const useTasks = (dayPlanId: string) => {
         ];
         mutateProjectTasks(updatedTasks, false);
         const { data, errors } = await client.models.DayProjectTask.create({
-          ...newTask,
+          task,
+          done: false,
           dayPlanProjectTasksId: dayPlanId,
           projectsDayTasksId: projectId,
         });

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -20,3 +20,9 @@ const { data, errors } = await client.models.DayPlan.create({
 Das führte zu Fehlern.
 
 ## Detaillierte Änderungen
+
+### Bug Fixes
+
+#### api
+
+- never force an ID for a new record [35d4256](https://github.com/cabcookie/personal-crm/commit/35d4256eb0379a3f874ddc6f360d826f21046b2f)

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,17 +1,22 @@
-# Testen von weiteren Backend Updates (Version :VERSION)
+# Fix: Datensätze in der Datenbank dürfen nicht mit einer ID angelegt werden (Version :VERSION)
 
-## Zusammenfassung der Änderungen
+## Neue Funktionen und Änderungen
 
-Im [Issue #2443 im Amplify Backend repo](https://github.com/aws-amplify/amplify-category-api/issues/2443) habe ich einen Fehler gemeldet, dass einzelne Datensätze zwar in der DynamoDB Tabelle zu sehen sind, aber die GraphQl Abfragen diese nicht ausspucken. Mir wurde geraten, das Amplify Backend auf eine neue Version zu updaten. Mir wurde außerdem geraten, "Secondary Indexes" einzurichten, um gezielter Datensätze aus DynamoDB abzurufen. Habe festgestellt, dass das etwas komplizierter ist, da ich hierbei auch das Backend auf die letzte Version upgraden müsste. Die neue Version unterstützt aber keine many-to-many Beziehungen mehr und das würde eine größere Veränderung nach sich ziehen, inklusive des Risikos von Datenverlust.
+Datensätze in der Datenbank wurden bisher mit einer ID erzeugt. Hier ein Beispiel:
 
-## Detailed changes
+```typescript
+const newDayPlan: DayPlan = {
+  id: crypto.randomUUID(),
+  day,
+  dayGoal,
+  done: false,
+};
+const { data, errors } = await client.models.DayPlan.create({
+  ...newDayPlan,
+  context,
+});
+```
 
-### Bug Fixes
+Das führte zu Fehlern.
 
-#### deps
-
-- trying to fix the AppSync resolvers with a backend update [89fd19d](https://github.com/cabcookie/personal-crm/commit/89fd19d4683ab9b76d89892a8b89857e3371013f)
-
-### Miscellaneous
-
-- added sandbox script [edbd25f](https://github.com/cabcookie/personal-crm/commit/edbd25f8b0c4d03f2cacbb4f51c1782045cedda8)
+## Detaillierte Änderungen


### PR DESCRIPTION
# Fix: Datensätze in der Datenbank dürfen nicht mit einer ID angelegt werden

## Neue Funktionen und Änderungen

Datensätze in der Datenbank wurden bisher mit einer ID erzeugt. Hier ein Beispiel:

```typescript
const newDayPlan: DayPlan = {
  id: crypto.randomUUID(),
  day,
  dayGoal,
  done: false,
};
const { data, errors } = await client.models.DayPlan.create({
  ...newDayPlan,
  context,
});
```

Das führte zu Fehlern.

## Detaillierte Änderungen

### Bug Fixes

#### api

- never force an ID for a new record [35d4256](https://github.com/cabcookie/personal-crm/commit/35d4256eb0379a3f874ddc6f360d826f21046b2f)
