### PR TITLE
Kontexte von Meetings und Projekten ändern und Projekten CRM Projekte verlinken

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -212,6 +212,31 @@ const schema = a.schema({
       createdOn: a.datetime(),
     })
     .authorization((allow) => [allow.owner()]),
+  CrmProjectProjects: a
+    .model({
+      owner: a
+        .string()
+        .authorization((allow) => [allow.owner().to(["read", "delete"])]),
+      projectId: a.id().required(),
+      crmProjectId: a.id().required(),
+      project: a.belongsTo("Projects", "projectId"),
+      crmProject: a.belongsTo("CrmProject", "crmProjectId"),
+    })
+    .authorization((allow) => [allow.owner()]),
+  CrmProject: a
+    .model({
+      owner: a
+        .string()
+        .authorization((allow) => [allow.owner().to(["read", "delete"])]),
+      name: a.string().required(),
+      crmId: a.string(),
+      annualRecurringRevenue: a.integer(),
+      totalContractVolume: a.integer(),
+      closeDate: a.date().required(),
+      projects: a.hasMany("CrmProjectProjects", "crmProjectId"),
+      stage: a.string().required(),
+    })
+    .authorization((allow) => [allow.owner()]),
   Projects: a
     .model({
       owner: a
@@ -231,6 +256,7 @@ const schema = a.schema({
       activities: a.hasMany("ProjectActivity", "projectsId"),
       dayTasks: a.hasMany("DayProjectTask", "projectsDayTasksId"),
       todos: a.hasMany("DayPlanTodo", "projectsTodosId"),
+      crmProjects: a.hasMany("CrmProjectProjects", "projectId"),
     })
     .authorization((allow) => [allow.owner()]),
 });

--- a/api/useCrmProject.ts
+++ b/api/useCrmProject.ts
@@ -1,0 +1,71 @@
+import { type Schema } from "@/amplify/data/resource";
+import { generateClient } from "aws-amplify/data";
+import useSWR from "swr";
+import {
+  CrmProject,
+  mapCrmProject,
+  selectionSetCrmProject,
+} from "./useCrmProjects";
+import { getDayOfDate } from "@/helpers/functional";
+import { handleApiErrors } from "./globals";
+import { Project, useProjectsContext } from "./ContextProjects";
+const client = generateClient<Schema>();
+
+const fetchCrmProject = (projectId?: string) => async () => {
+  if (!projectId) return;
+  const { data, errors } = await client.models.CrmProject.get(
+    { id: projectId },
+    { selectionSet: selectionSetCrmProject }
+  );
+  if (errors) throw errors;
+  return mapCrmProject(data);
+};
+
+const useCrmProject = (projectId?: string) => {
+  const {
+    data: crmProject,
+    error: errorCrmProject,
+    isLoading: loadingCrmProject,
+    mutate,
+  } = useSWR(`/api/crm-projects/${projectId}`, fetchCrmProject(projectId));
+  const { projects, mutateProjects } = useProjectsContext();
+
+  const createCrmProject = async (project: CrmProject) => {
+    const { data: newProject, errors: projectErrors } =
+      await client.models.CrmProject.create({
+        closeDate: getDayOfDate(project.closeDate),
+        name: project.name,
+        stage: project.stage,
+        annualRecurringRevenue: project.arr,
+        crmId: project.crmId,
+        totalContractVolume: project.tcv,
+      });
+    if (projectErrors) {
+      handleApiErrors(projectErrors, "Error creating CRM project");
+      return;
+    }
+    if (!newProject) return;
+    const { data, errors } = await client.models.CrmProjectProjects.create({
+      projectId: project.projectIds[0],
+      crmProjectId: newProject.id,
+    });
+    if (errors) {
+      handleApiErrors(errors, "Error linking CRM project to project");
+      return;
+    }
+    if (projects) {
+      mutateProjects(
+        projects.map((p) =>
+          p.id !== project.projectIds[0]
+            ? p
+            : { ...p, crmProjectIds: [...p.crmProjectIds, newProject.id] }
+        )
+      );
+    }
+    return newProject.id;
+  };
+
+  return { crmProject, errorCrmProject, loadingCrmProject, createCrmProject };
+};
+
+export default useCrmProject;

--- a/api/useCrmProjects.ts
+++ b/api/useCrmProjects.ts
@@ -1,0 +1,134 @@
+import { type Schema } from "@/amplify/data/resource";
+import { SelectionSet, generateClient } from "aws-amplify/data";
+import useSWR from "swr";
+import { flow } from "lodash/fp";
+import {
+  addDaysToDate,
+  getDayOfDate,
+  toISODateString,
+} from "@/helpers/functional";
+const client = generateClient<Schema>();
+
+export type CrmStage =
+  | "Prospect"
+  | "Qualified"
+  | "Technical Validation"
+  | "Business Validation"
+  | "Committed"
+  | "Closed Lost"
+  | "Launched";
+
+export const crmStages = [
+  "Prospect",
+  "Qualified",
+  "Technical Validation",
+  "Business Validation",
+  "Committed",
+  "Closed Lost",
+  "Launched",
+];
+
+export type CrmProject = {
+  id: string;
+  name: string;
+  crmId?: string;
+  arr: number;
+  tcv: number;
+  closeDate: Date;
+  projectIds: string[];
+  stage: string;
+};
+
+export const selectionSetCrmProject = [
+  "id",
+  "name",
+  "crmId",
+  "annualRecurringRevenue",
+  "totalContractVolume",
+  "closeDate",
+  "projects.project.id",
+  "stage",
+] as const;
+
+export const mapCrmProject: (data: CrmProjectData) => CrmProject = ({
+  id,
+  name,
+  crmId,
+  annualRecurringRevenue,
+  totalContractVolume,
+  closeDate,
+  projects,
+  stage,
+}) => ({
+  id,
+  name,
+  crmId: crmId || undefined,
+  arr: annualRecurringRevenue || 0,
+  tcv: totalContractVolume || 0,
+  closeDate: new Date(closeDate),
+  projectIds: projects.map(({ project: { id } }) => id),
+  stage,
+});
+
+type CrmProjectData = SelectionSet<
+  Schema["CrmProject"],
+  typeof selectionSetCrmProject
+>;
+
+type FetchCrmProjectsWithTokenFn = (
+  token?: string
+) => Promise<CrmProjectData[] | undefined>;
+
+const fetchCrmProjectsWithToken: FetchCrmProjectsWithTokenFn = async (
+  token
+) => {
+  const closed = {
+    or: [{ stage: { eq: "Launched" } }, { stage: { eq: "Closed Lost" } }],
+  };
+
+  const { data, errors, nextToken } = await client.models.CrmProject.list({
+    filter: {
+      or: [
+        { not: closed },
+        {
+          and: [
+            closed,
+            {
+              closeDate: {
+                ge: flow(
+                  addDaysToDate(-14),
+                  toISODateString,
+                  getDayOfDate
+                )(new Date()),
+              },
+            },
+          ],
+        },
+      ],
+    },
+    selectionSet: selectionSetCrmProject,
+    nextToken: token,
+  });
+  if (errors) throw errors;
+  if (!nextToken) return data;
+  return [...data, ...((await fetchCrmProjectsWithToken(nextToken)) || [])];
+};
+
+const fetchCrmProjects = async () => {
+  return (await fetchCrmProjectsWithToken())
+    ?.map(mapCrmProject)
+    .sort((a, b) => a.closeDate.getTime() - b.closeDate.getTime());
+};
+
+const useCrmProjects = () => {
+  const {
+    data: crmProjects,
+    error: errorCrmProjects,
+    isLoading: loadingCrmProjects,
+    mutate,
+  } = useSWR("/api/crm-projects/", fetchCrmProjects);
+
+  return { crmProjects, errorCrmProjects, loadingCrmProjects };
+};
+
+export default useCrmProjects;

--- a/api/useMeeting.ts
+++ b/api/useMeeting.ts
@@ -3,6 +3,7 @@ import { generateClient } from "aws-amplify/data";
 import useSWR from "swr";
 import { Meeting, mapMeeting, meetingSelectionSet } from "./useMeetings";
 import { handleApiErrors } from "./globals";
+import { Context } from "@/contexts/ContextContext";
 const client = generateClient<Schema>();
 
 type MeetingUpdateProps = {
@@ -75,6 +76,19 @@ const useMeeting = (meetingId?: string) => {
     return data.id;
   };
 
+  const updateMeetingContext = async (newContext: Context) => {
+    if (!meeting) return;
+    const { data, errors } = await client.models.Meeting.update({
+      id: meeting.id,
+      context: newContext,
+    });
+    if (errors) {
+      handleApiErrors(errors, "Error updating meeting's context");
+      return;
+    }
+    return data.id;
+  };
+
   return {
     meeting,
     errorMeeting,
@@ -82,6 +96,7 @@ const useMeeting = (meetingId?: string) => {
     updateMeeting,
     createMeetingParticipant,
     createMeetingActivity,
+    updateMeetingContext,
   };
 };
 

--- a/components/navigation-menu/OtherNavigationSection.tsx
+++ b/components/navigation-menu/OtherNavigationSection.tsx
@@ -16,6 +16,7 @@ type MenuItem = {
 const menuItems: MenuItem[] = [
   { name: "Projects", link: "/projects" },
   { name: "Accounts", link: "/accounts" },
+  { name: "CRM Projects", link: "/crm-projects" },
   // { name: "People", link: "/people" },
 ];
 

--- a/components/ui-elements/context-warning/ContextWarning.module.css
+++ b/components/ui-elements/context-warning/ContextWarning.module.css
@@ -1,0 +1,4 @@
+.warning {
+  color: red;
+  font-weight: bold;
+}

--- a/components/ui-elements/context-warning/context-warning.tsx
+++ b/components/ui-elements/context-warning/context-warning.tsx
@@ -1,0 +1,38 @@
+import { Context, useContextContext } from "@/contexts/ContextContext";
+import { FC } from "react";
+import styles from "./ContextWarning.module.css";
+import SubmitButton from "../submit-button";
+
+type ContextWarningProps = {
+  recordContext?: Context;
+  className?: string;
+};
+
+const ContextWarning: FC<ContextWarningProps> = ({
+  recordContext,
+  className,
+}) => {
+  const { context, setContext } = useContextContext();
+  return (
+    context !== recordContext && (
+      <div className={className}>
+        You are working currently in the{" "}
+        <span className={styles.warning}>{context?.toUpperCase()}</span>{" "}
+        context. Your project is not visible in this context. Do you want to
+        switch to the{" "}
+        <span className={styles.warning}>{recordContext?.toUpperCase()}</span>
+        context?
+        <SubmitButton
+          onClick={() => {
+            if (!recordContext) return;
+            setContext(recordContext);
+          }}
+        >
+          Yes
+        </SubmitButton>
+      </div>
+    )
+  );
+};
+
+export default ContextWarning;

--- a/components/ui-elements/crm-project-details/CrmProjectDetails.module.css
+++ b/components/ui-elements/crm-project-details/CrmProjectDetails.module.css
@@ -1,0 +1,26 @@
+.oneLine {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  width: 100%;
+}
+
+.oneRow {
+  display: flex;
+  flex-direction: row;
+  gap: 1rem;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+  margin-bottom: 1rem;
+}
+
+@media (max-width: 480px) {
+  .oneRow {
+    flex-direction: column;
+  }
+}
+
+.fullWidth {
+  width: 100%;
+}

--- a/components/ui-elements/crm-project-details/crm-project-details.tsx
+++ b/components/ui-elements/crm-project-details/crm-project-details.tsx
@@ -1,0 +1,132 @@
+import useCrmProject from "@/api/useCrmProject";
+import { FC, FormEvent, useState } from "react";
+import RecordDetails from "../record-details/record-details";
+import SubmitButton from "../submit-button";
+import {
+  addDaysToDate,
+  makeRevenueString,
+  toLocaleDateString,
+} from "@/helpers/functional";
+import CrmProjectForm from "./crm-project-form";
+import { CrmProject } from "@/api/useCrmProjects";
+import Link from "next/link";
+
+type CrmProjectDetailsProps = {
+  projectId: string;
+  crmProjectId: string;
+  crmProjectDetails?: boolean;
+};
+
+const makeNewCrmProject = (projectId: string): CrmProject => ({
+  id: crypto.randomUUID(),
+  name: "",
+  arr: 0,
+  closeDate: addDaysToDate(60)(new Date()),
+  projectIds: [projectId],
+  stage: "Prospect",
+  tcv: 0,
+  crmId: "",
+});
+
+const CrmProjectDetails: FC<CrmProjectDetailsProps> = ({
+  projectId,
+  crmProjectId,
+  crmProjectDetails,
+}) => {
+  const { crmProject, createCrmProject } = useCrmProject(crmProjectId);
+  const [newCrmProject, setNewCrmProject] = useState<CrmProject | undefined>(
+    !crmProject ? makeNewCrmProject(projectId) : undefined
+  );
+
+  const handleFormSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!newCrmProject) return;
+    const data = await createCrmProject(newCrmProject);
+    if (data) setNewCrmProject(makeNewCrmProject(projectId));
+  };
+
+  const getCrmId = (input: string) => {
+    if (/^006\w{15}$/.test(input)) return input;
+    const match = input.match(/\/Opportunity\/(006\w{15})\//);
+    if (match) return match[1];
+    return "";
+  };
+
+  const handleUpdateNewProject = (fieldName: string, val: string | Date) => {
+    if (!newCrmProject) return;
+    switch (fieldName) {
+      case "name":
+        setNewCrmProject({ ...newCrmProject, name: val as string });
+        break;
+      case "arr":
+        setNewCrmProject({ ...newCrmProject, arr: parseInt(val as string) });
+        break;
+      case "tcv":
+        setNewCrmProject({ ...newCrmProject, tcv: parseInt(val as string) });
+        break;
+      case "stage":
+        setNewCrmProject({ ...newCrmProject, stage: val as string });
+        break;
+      case "closeDate":
+        setNewCrmProject({ ...newCrmProject, closeDate: val as Date });
+        break;
+      case "crmId":
+        const crmId = getCrmId(val as string);
+        setNewCrmProject({ ...newCrmProject, crmId });
+        break;
+
+      default:
+        break;
+    }
+  };
+
+  return !crmProject ? (
+    <RecordDetails title="Create New CRM Project">
+      <form onSubmit={handleFormSubmit}>
+        <CrmProjectForm
+          crmProject={newCrmProject}
+          onChange={handleUpdateNewProject}
+        />
+        <SubmitButton type="submit">Create CRM Project</SubmitButton>
+      </form>
+    </RecordDetails>
+  ) : (
+    <RecordDetails
+      title={
+        <>
+          CRM:{" "}
+          {crmProject.crmId && crmProject.crmId.length > 6 ? (
+            <Link
+              href={`https://aws-crm.lightning.force.com/lightning/r/Opportunity/${crmProject.crmId}/view`}
+              target="_blank"
+            >
+              {crmProject.name}
+            </Link>
+          ) : (
+            crmProject.name
+          )}{" "}
+          (Stage: {crmProject.stage})
+        </>
+      }
+    >
+      <div>
+        {crmProject.arr > 0 && (
+          <div>
+            Annual recurring revenue: {makeRevenueString(crmProject.arr)}
+          </div>
+        )}
+        {crmProject.tcv > 0 && (
+          <div>Total contract volume: {makeRevenueString(crmProject.tcv)}</div>
+        )}
+        <div>Close date: {toLocaleDateString(crmProject.closeDate)}</div>
+        {crmProjectDetails && (
+          <div style={{ fontSize: "1.2rem", color: "red" }}>
+            Projects can not be updated at the moment
+          </div>
+        )}
+      </div>
+    </RecordDetails>
+  );
+};
+
+export default CrmProjectDetails;

--- a/components/ui-elements/crm-project-details/crm-project-form.tsx
+++ b/components/ui-elements/crm-project-details/crm-project-form.tsx
@@ -1,0 +1,99 @@
+import { CrmProject, crmStages } from "@/api/useCrmProjects";
+import { FC, useState } from "react";
+import styles from "./CrmProjectDetails.module.css";
+import Input from "../form-fields/input";
+import DateSelector from "../date-selector";
+import Select from "react-select";
+import Link from "next/link";
+
+type CrmProjectFormProps = {
+  crmProject?: CrmProject;
+  onChange: (fieldName: string, val: string | Date) => void;
+};
+
+const CrmProjectForm: FC<CrmProjectFormProps> = ({ crmProject, onChange }) => {
+  const [mappedOptions] = useState(
+    crmStages.map((stage) => ({ value: stage, label: stage }))
+  );
+  const [selectedOption, setSelectedOption] = useState<any>(
+    mappedOptions.find(({ label }) => label === crmProject?.stage)
+  );
+
+  const selectStage = (selectedOption: any) => {
+    onChange("stage", selectedOption.label);
+  };
+
+  return (
+    crmProject && (
+      <div>
+        <div className={styles.oneRow}>
+          <Input
+            value={crmProject.name}
+            onChange={(newVal) => onChange("name", newVal)}
+            label="Name"
+            placeholder="Opportunity Name"
+            className={styles.fullWidth}
+            inputClassName={styles.fullWidth}
+          />
+          <Input
+            value={crmProject.crmId || ""}
+            onChange={(newVal) => onChange("crmId", newVal)}
+            label={
+              <div className={styles.oneLine}>
+                <div>CRM ID</div>
+                {crmProject.crmId && crmProject.crmId.length > 6 && (
+                  <Link
+                    href={`https://aws-crm.lightning.force.com/lightning/r/Opportunity/${crmProject.crmId}/view`}
+                    target="_blank"
+                  >
+                    <small>Visit CRM</small>
+                  </Link>
+                )}
+              </div>
+            }
+            placeholder="Paste Opportunity URL or ID..."
+            className={styles.fullWidth}
+            inputClassName={styles.fullWidth}
+          />
+        </div>
+        <div className={styles.oneRow}>
+          <Input
+            value={crmProject.arr.toString()}
+            onChange={(newval) => onChange("arr", newval)}
+            label="Annual Recurring Revenue"
+            className={styles.fullWidth}
+            inputClassName={styles.fullWidth}
+          />
+          <Input
+            value={crmProject.tcv.toString()}
+            onChange={(newval) => onChange("tcv", newval)}
+            label="Total Contract Volume"
+            className={styles.fullWidth}
+            inputClassName={styles.fullWidth}
+          />
+        </div>
+        <div className={styles.oneRow}>
+          <div className={styles.fullWidth}>
+            <div>Stage</div>
+            <Select
+              options={mappedOptions}
+              onChange={selectStage}
+              value={selectedOption}
+              isSearchable
+              className={styles.fullWidth}
+            />
+          </div>
+          <div className={styles.fullWidth}>
+            <div>Close Date</div>
+            <DateSelector
+              date={crmProject.closeDate}
+              setDate={(date) => onChange("closeDate", date)}
+            />
+          </div>
+        </div>
+      </div>
+    )
+  );
+};
+
+export default CrmProjectForm;

--- a/components/ui-elements/form-fields/input.tsx
+++ b/components/ui-elements/form-fields/input.tsx
@@ -1,0 +1,38 @@
+import { FC, ReactNode } from "react";
+
+type InputProps = {
+  value: string;
+  onChange: (val: string) => void;
+  label?: ReactNode;
+  placeholder?: string;
+  className?: string;
+  labelClassName?: string;
+  inputClassName?: string;
+  autoFocus?: boolean;
+};
+
+const Input: FC<InputProps> = ({
+  value,
+  onChange,
+  label,
+  placeholder,
+  className,
+  autoFocus,
+  labelClassName,
+  inputClassName,
+}) => {
+  return (
+    <div className={className}>
+      {label && <div className={labelClassName}>{label}</div>}
+      <input
+        className={inputClassName}
+        value={value}
+        autoFocus={autoFocus}
+        onChange={(event) => onChange(event.target.value)}
+        placeholder={placeholder}
+      />
+    </div>
+  );
+};
+
+export default Input;

--- a/components/ui-elements/notes-writer/NotesWriter.module.css
+++ b/components/ui-elements/notes-writer/NotesWriter.module.css
@@ -2,13 +2,9 @@
   width: 100%;
 }
 
-.title {
-  margin: 1rem 1rem 0 1rem;
-  padding: 0;
-}
-
 .editorInput {
-  padding: 1rem;
+  margin: -0.5rem;
+  padding: 0.5rem;
   border-radius: 0.4rem;
   background-color: inherit;
   transition: background-color 1s ease;

--- a/components/ui-elements/notes-writer/NotesWriter.tsx
+++ b/components/ui-elements/notes-writer/NotesWriter.tsx
@@ -1,4 +1,4 @@
-import React, { FC, useEffect, useState } from "react";
+import React, { FC, ReactNode, useEffect, useState } from "react";
 import { createEditor, Descendant } from "slate";
 import { withHistory } from "slate-history";
 import { Editable, Slate, withReact } from "slate-react";
@@ -9,6 +9,7 @@ import {
   transformNotesToMd,
 } from "./notes-writer-helpers";
 import styles from "./NotesWriter.module.css";
+import RecordDetails from "../record-details/record-details";
 
 type NotesWriterProps = {
   notes: string;
@@ -19,7 +20,7 @@ type NotesWriterProps = {
   unsaved?: boolean;
   autoFocus?: boolean;
   placeholder?: string;
-  title?: string;
+  title?: ReactNode;
 };
 
 const NotesWriter: FC<NotesWriterProps> = ({
@@ -47,8 +48,7 @@ const NotesWriter: FC<NotesWriterProps> = ({
   };
 
   return (
-    <div className={`${styles.fullWidth}`}>
-      <h3 className={styles.title}>{title}</h3>
+    <RecordDetails title={title} className={styles.fullWidth}>
       <Slate
         editor={editor}
         initialValue={transformMdToNotes(notes)}
@@ -61,7 +61,7 @@ const NotesWriter: FC<NotesWriterProps> = ({
           placeholder={placeholder || "Start taking notes..."}
         />
       </Slate>
-    </div>
+    </RecordDetails>
   );
 };
 

--- a/components/ui-elements/project-details/ProjectDetails.module.css
+++ b/components/ui-elements/project-details/ProjectDetails.module.css
@@ -1,18 +1,10 @@
 .oneRow {
   display: flex;
+  flex-direction: row;
   gap: 1rem;
   width: 100%;
-  border: 1px solid #ccc;
-  border-radius: 0.4rem;
-  margin-bottom: 1rem;
-}
-
-.accounts {
-  width: 100%;
-  border: 1px solid #ccc;
-  border-radius: 0.4rem;
-  margin-bottom: 1rem;
-  font-size: 1.4rem;
+  padding: 0;
+  margin: 0;
 }
 
 .wrapper {
@@ -24,17 +16,11 @@
 }
 
 .title {
-  margin: 1rem 1rem 0 1rem;
-  padding: 0;
-}
-
-.text {
-  margin: 1rem;
-  padding: 0;
+  margin: 0;
 }
 
 @media (max-width: 640px) {
   .oneRow {
-    display: block;
+    flex-direction: column;
   }
 }

--- a/components/ui-elements/project-details/next-actions.tsx
+++ b/components/ui-elements/project-details/next-actions.tsx
@@ -1,4 +1,4 @@
-import { FC, useState } from "react";
+import { FC, ReactNode, useState } from "react";
 import NotesWriter from "../notes-writer/NotesWriter";
 import { Descendant } from "slate";
 import { TransformNotesToMdFunction } from "../notes-writer/notes-writer-helpers";
@@ -12,7 +12,7 @@ type NextActionsProps = {
 };
 
 type NextActionHelperProps = {
-  title: string;
+  title: ReactNode;
   actions: string;
   saveFn: (actions: string) => Promise<string | undefined>;
 };

--- a/components/ui-elements/project-details/project-dates.tsx
+++ b/components/ui-elements/project-details/project-dates.tsx
@@ -26,9 +26,7 @@ const ProjectDatesHelper: FC<ProjectDatesHelperProps> = ({
   return (
     <div className={styles.wrapper}>
       <h3 className={styles.title}>{title}</h3>
-      <div className={styles.text}>
-        <DateSelector date={date} setDate={updateDateFn} />
-      </div>
+      <DateSelector date={date} setDate={updateDateFn} />
     </div>
   );
 };

--- a/components/ui-elements/project-notes-form/project-notes-form.tsx
+++ b/components/ui-elements/project-notes-form/project-notes-form.tsx
@@ -9,6 +9,7 @@ import { TransformNotesToMdFunction } from "../notes-writer/notes-writer-helpers
 import ActivityMetaData from "../activity-meta-data";
 import { debouncedUpdateNotes } from "../activity-helper";
 import ProjectDetails from "../project-details/project-details";
+import RecordDetails from "../record-details/record-details";
 
 type ProjectNotesFormProps = {
   className?: string;
@@ -54,13 +55,16 @@ const ProjectNotesForm: FC<ProjectNotesFormProps> = ({
 
   return (
     <div className={className}>
-      {activity?.projectIds.map((id) => (
-        <div key={id}>
-          <ProjectName projectId={id} />
-          <ProjectDetails projectId={id} />
-        </div>
-      ))}
-      <ProjectSelector onChange={handleSelectProject} allowCreateProjects />
+      <RecordDetails title="For projects">
+        {activity?.projectIds.map((id) => (
+          <div key={id}>
+            <ProjectName projectId={id} />
+            <ProjectDetails projectId={id} />
+          </div>
+        ))}
+        <ProjectSelector onChange={handleSelectProject} allowCreateProjects />
+      </RecordDetails>
+
       <NotesWriter
         notes={activity?.notes || ""}
         saveNotes={handleNotesUpdate}

--- a/components/ui-elements/record-details/RecordDetails.module.css
+++ b/components/ui-elements/record-details/RecordDetails.module.css
@@ -1,0 +1,16 @@
+.infoBox {
+  width: 100%;
+  border: 1px solid #ccc;
+  border-radius: 0.4rem;
+  margin-bottom: 1rem;
+  font-size: 1.4rem;
+}
+
+.title {
+  margin: 1rem 1rem 0 1rem;
+  padding: 0;
+}
+
+.contentContainer {
+  padding: 1rem;
+}

--- a/components/ui-elements/record-details/record-details.tsx
+++ b/components/ui-elements/record-details/record-details.tsx
@@ -1,0 +1,27 @@
+import { FC, ReactNode } from "react";
+import styles from "./RecordDetails.module.css";
+
+type RecordDetailsProps = {
+  className?: string;
+  title?: ReactNode;
+  children: ReactNode;
+  contentClassName?: string;
+};
+
+const RecordDetails: FC<RecordDetailsProps> = ({
+  className,
+  title,
+  children,
+  contentClassName,
+}) => {
+  return (
+    <div className={`${styles.infoBox} ${className}`}>
+      {title && <h3 className={styles.title}>{title}</h3>}
+      <div className={contentClassName || styles.contentContainer}>
+        {children}
+      </div>
+    </div>
+  );
+};
+
+export default RecordDetails;

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,5 +1,11 @@
-# Tagespläne und Meetings vollständig laden (Version :VERSION)
+# Kontexte von Meetings und Projekten ändern und Projekten CRM Projekte verlinken (Version :VERSION)
 
-## Fehlerbehebungen
+## Kontexte von Meetings und Projekten ändern
 
-Es wurden nicht alle Tagespläne und Meetings geladen, da wir im Moment einen Table Scan durchführen und nur bis zu 100 Datensätze prüfen und dann einen `nextToken` erhalten. Den verwenden wir jetzt, um weitere Datensätze zu laden, bis kein `nextToken` mehr zurück gegeben wird.
+Kontexte von Meetings und Projekten können nun nachträglich geändert werden. Wenn der Kontext geändert wird, erscheint eine Warnung, dass das Projekt beim nächsten Laden verschwinden wird und es wird empfohlen, in den Kontext zu wechseln. Das liegt daran, dass wir die Projekte abhängig vom Kontext zentral laden, so dass sie an verschiedenen Stellen in der App zur Verfügung stehen. Wenn nun der Kontext eines Projekts gewechselt wird, wird es auch aus dieser Liste gelöscht.
+
+Bei Meetings besteht dieses Problem nicht, da Meetings immer nach der ID geladen werden. Das Meeting verschwindet dann nur aus der Listenansicht, aber das ist auch erwartet.
+
+## CRM Projekte verlinken
+
+In der Projektliste werden verlinkte Projekte im CRM System angezeigt. In der Detailansicht der Projekte können neue CRM Projekte angelegt/verlinkt werden. Es ist im Moment noch nicht möglich, CRM Projekte zu editieren.

--- a/helpers/functional.ts
+++ b/helpers/functional.ts
@@ -67,3 +67,9 @@ export const sortByDate =
   };
 export const wait = (ms: number) =>
   new Promise((resolve) => setTimeout(resolve, ms));
+export const makeRevenueString = (revenue: number) => {
+  const inM = revenue > 800000;
+  const val = Math.round((revenue / (inM ? 1000000 : 1000)) * 100) / 100;
+  const label = inM ? "M" : "k";
+  return `$${val}${label}`;
+};

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -32,7 +32,7 @@ function App(appProps: AppProps) {
       <Head>
         <meta
           name="viewport"
-          content="width=device-width, initial-scale=1, viewport-fit=cover"
+          content="width=device-width, initial-scale=1, viewport-fit=cover,user-scalable=no"
         ></meta>
       </Head>
       <ContextContextProvider useContextHook={() => contextLocalStorage}>

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -7,10 +7,6 @@ export default function Document() {
         <meta charSet="utf-8"></meta>
         <meta name="apple-mobile-web-app-title" content="Impulso"></meta>
         <meta name="application-name" content="Impulso"></meta>
-        <meta
-          name="viewport"
-          content="width=device-width,initial-scale=1.0,user-scalable=no"
-        ></meta>
       </Head>
       <body>
         <Main />

--- a/pages/crm-projects/index.tsx
+++ b/pages/crm-projects/index.tsx
@@ -1,0 +1,15 @@
+import useCrmProjects from "@/api/useCrmProjects";
+import MainLayout from "@/components/layouts/MainLayout";
+
+const CrmProjectsPage = () => {
+  const { crmProjects } = useCrmProjects();
+  return (
+    <MainLayout title="CRM Projects" sectionName="CRM Projects">
+      {crmProjects?.map(({ id, name }) => (
+        <div key={id}>{name}</div>
+      ))}
+    </MainLayout>
+  );
+};
+
+export default CrmProjectsPage;

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -82,7 +82,12 @@ const ProjectDetailPage = () => {
         <div>
           <SavedState saved={projectDetailsSaved} />
           {projectId && (
-            <ProjectDetails projectId={projectId} includeAccounts />
+            <ProjectDetails
+              projectId={projectId}
+              includeAccounts
+              showContext
+              showCrmDetails
+            />
           )}
           {[newActivityId, ...(project?.activityIds || [])].map((id) => (
             <ActivityComponent


### PR DESCRIPTION
# Kontexte von Meetings und Projekten ändern und Projekten CRM Projekte verlinken

## Kontexte von Meetings und Projekten ändern

Kontexte von Meetings und Projekten können nun nachträglich geändert werden. Wenn der Kontext geändert wird, erscheint eine Warnung, dass das Projekt beim nächsten Laden verschwinden wird und es wird empfohlen, in den Kontext zu wechseln. Das liegt daran, dass wir die Projekte abhängig vom Kontext zentral laden, so dass sie an verschiedenen Stellen in der App zur Verfügung stehen. Wenn nun der Kontext eines Projekts gewechselt wird, wird es auch aus dieser Liste gelöscht.

Bei Meetings besteht dieses Problem nicht, da Meetings immer nach der ID geladen werden. Das Meeting verschwindet dann nur aus der Listenansicht, aber das ist auch erwartet.

## CRM Projekte verlinken

In der Projektliste werden verlinkte Projekte im CRM System angezeigt. In der Detailansicht der Projekte können neue CRM Projekte angelegt/verlinkt werden. Es ist im Moment noch nicht möglich, CRM Projekte zu editieren.
