### PR TITLE
Visuelle Fehler bereinigen (Territorys und Accounts)

### DIFF
--- a/api/ContextProjects.tsx
+++ b/api/ContextProjects.tsx
@@ -6,13 +6,14 @@ import {
 import { toast } from "@/components/ui/use-toast";
 import { Context } from "@/contexts/ContextContext";
 import { addDaysToDate, toISODateString } from "@/helpers/functional";
+import { calcPipeline } from "@/helpers/projects";
 import { SelectionSet, generateClient } from "aws-amplify/data";
-import { differenceInCalendarMonths, differenceInDays } from "date-fns";
-import { flow, map, max, round, sum } from "lodash/fp";
+import { differenceInDays } from "date-fns";
+import { flow } from "lodash/fp";
 import { FC, ReactNode, createContext, useContext } from "react";
 import useSWR, { KeyedMutator } from "swr";
 import { handleApiErrors } from "./globals";
-import { CRM_STAGES, STAGES_PROBABILITY, TCrmStages } from "./useCrmProject";
+import { CRM_STAGES, TCrmStages } from "./useCrmProject";
 const client = generateClient<Schema>();
 
 interface ProjectsContextType {
@@ -76,6 +77,7 @@ export type Project = {
   id: string;
   project: string;
   done: boolean;
+  order: number;
   doneOn?: Date;
   dueOn?: Date;
   onHoldTill?: Date;
@@ -85,7 +87,6 @@ export type Project = {
   accountIds: string[];
   activityIds: string[];
   crmProjects: CrmProjectData[];
-  priority: number;
 };
 
 const selectionSet = [
@@ -118,19 +119,9 @@ type ProjectData = SelectionSet<
   Schema["Projects"]["type"],
   typeof selectionSet
 >;
+export type CrmDataProps = ProjectData["crmProjects"][number];
 
-export type CrmDataProps = {
-  crmProject: {
-    id: string;
-    annualRecurringRevenue?: number | null;
-    totalContractVolume?: number | null;
-    closeDate: string;
-    isMarketplace?: boolean | null;
-    stage: string;
-  };
-};
-
-const mapCrmData = ({
+export const mapCrmData = ({
   crmProject: {
     id,
     annualRecurringRevenue,
@@ -147,50 +138,6 @@ const mapCrmData = ({
   closeDate: new Date(closeDate),
   stage: CRM_STAGES.find((s) => s === stage) || "Prospect",
 });
-
-export interface ICalcRevenueTwoYears {
-  arr: number;
-  tcv: number;
-  closeDate: Date;
-  isMarketPlace?: boolean;
-  stage: TCrmStages;
-}
-
-const maxOfArray = (val: number[]): number => max(val) || 0;
-
-export const getProbability = (stage: string): number =>
-  (STAGES_PROBABILITY.find((s) => s.stage === stage)?.probability || 0) / 100;
-
-export const calcRevenueTwoYears = (crmProject: ICalcRevenueTwoYears) =>
-  flow(
-    ({
-      arr,
-      tcv,
-      closeDate,
-      isMarketPlace,
-      stage,
-    }: ICalcRevenueTwoYears): number[] => [
-      (arr / 12) *
-        (24 - differenceInCalendarMonths(closeDate, new Date())) *
-        getProbability(stage),
-      (tcv / (isMarketPlace ? 2 : 1)) * getProbability(stage),
-    ],
-    maxOfArray,
-    round
-  )(crmProject);
-
-const calcProjectPriority = ({
-  arr,
-  tcv,
-  closeDate,
-  isMarketPlace,
-}: CrmProjectData): number =>
-  Math.round(
-    Math.max(
-      (arr / 12) * (24 - differenceInCalendarMonths(closeDate, new Date())),
-      tcv / (isMarketPlace ? 2 : 1)
-    ) / 100000
-  );
 
 const mapProject: (project: ProjectData) => Project = ({
   id,
@@ -245,7 +192,13 @@ const mapProject: (project: ProjectData) => Project = ({
     .sort((a, b) => b.finishedOn.getTime() - a.finishedOn.getTime())
     .map(({ id }) => id),
   crmProjects: crmProjects.map(mapCrmData),
-  priority: flow(map(mapCrmData), map(calcProjectPriority), sum)(crmProjects),
+  order: calcPipeline([
+    {
+      projects: {
+        crmProjects,
+      },
+    },
+  ]),
 });
 
 const fetchProjects = (context?: Context) => async () => {
@@ -299,7 +252,7 @@ export const ProjectsContextProvider: FC<ProjectsContextProviderProps> = ({
       accountIds: [],
       activityIds: [],
       crmProjects: [],
-      priority: 0,
+      order: 0,
     };
 
     const updatedProjects = [...(projects || []), newProject];

--- a/api/useCrmProject.ts
+++ b/api/useCrmProject.ts
@@ -10,6 +10,16 @@ import {
 } from "./useCrmProjects";
 const client = generateClient<Schema>();
 
+export const STAGES_PROBABILITY = [
+  { stage: "Prospect", probability: 0 },
+  { stage: "Qualified", probability: 20 },
+  { stage: "Technical Validation", probability: 40 },
+  { stage: "Business Validation", probability: 60 },
+  { stage: "Committed", probability: 80 },
+  { stage: "Closed Lost", probability: 0 },
+  { stage: "Launched", probability: 100 },
+] as const;
+
 export const CRM_STAGES = [
   "Prospect",
   "Qualified",
@@ -20,7 +30,7 @@ export const CRM_STAGES = [
   "Launched",
 ] as const;
 
-export type TCrmStages = (typeof CRM_STAGES)[number];
+export type TCrmStages = (typeof STAGES_PROBABILITY)[number]["stage"];
 
 export type CrmProjectOnChangeFields = {
   name?: string;

--- a/api/useCrmProjects.ts
+++ b/api/useCrmProjects.ts
@@ -1,28 +1,16 @@
 import { type Schema } from "@/amplify/data/resource";
 import {
   addDaysToDate,
-  formatRevenue,
   getDayOfDate,
   toISODateString,
 } from "@/helpers/functional";
 import { SelectionSet, generateClient } from "aws-amplify/data";
-import { flow, map, sum } from "lodash/fp";
+import { flow } from "lodash/fp";
 import useSWR from "swr";
-import {
-  ICalcRevenueTwoYears,
-  Project,
-  calcRevenueTwoYears,
-  useProjectsContext,
-} from "./ContextProjects";
+import { Project, useProjectsContext } from "./ContextProjects";
 import { handleApiErrors } from "./globals";
 import { CRM_STAGES, TCrmStages } from "./useCrmProject";
 const client = generateClient<Schema>();
-
-export const make2YearsRevenueText = (revenue: number) =>
-  `Revenue next 2Ys: ${formatRevenue(revenue)}`;
-
-export const getRevenue2Years = (projects: ICalcRevenueTwoYears[]) =>
-  make2YearsRevenueText(flow(map(calcRevenueTwoYears), sum)(projects));
 
 export type CrmProject = {
   id: string;

--- a/api/useCrmProjects.ts
+++ b/api/useCrmProjects.ts
@@ -1,7 +1,7 @@
 import { type Schema } from "@/amplify/data/resource";
 import {
   addDaysToDate,
-  formatUsdCurrency,
+  formatRevenue,
   getDayOfDate,
   toISODateString,
 } from "@/helpers/functional";
@@ -15,14 +15,14 @@ import {
   useProjectsContext,
 } from "./ContextProjects";
 import { handleApiErrors } from "./globals";
+import { CRM_STAGES, TCrmStages } from "./useCrmProject";
 const client = generateClient<Schema>();
 
+export const make2YearsRevenueText = (revenue: number) =>
+  `Revenue next 2Ys: ${formatRevenue(revenue)}`;
+
 export const getRevenue2Years = (projects: ICalcRevenueTwoYears[]) =>
-  `Revenue next 2Ys: ${flow(
-    map(calcRevenueTwoYears),
-    sum,
-    formatUsdCurrency
-  )(projects)}`;
+  make2YearsRevenueText(flow(map(calcRevenueTwoYears), sum)(projects));
 
 export type CrmProject = {
   id: string;
@@ -33,7 +33,7 @@ export type CrmProject = {
   isMarketplace: boolean;
   closeDate: Date;
   projectIds: string[];
-  stage: string;
+  stage: TCrmStages;
 };
 
 export const selectionSetCrmProject = [
@@ -67,7 +67,7 @@ export const mapCrmProject: (data: CrmProjectData) => CrmProject = ({
   isMarketplace: !!isMarketplace,
   closeDate: new Date(closeDate),
   projectIds: projects.map(({ project: { id } }) => id),
-  stage,
+  stage: CRM_STAGES.find((s) => s === stage) || "Prospect",
 });
 
 type CrmProjectData = SelectionSet<
@@ -144,6 +144,7 @@ const useCrmProjects = () => {
                 tcv: project.tcv,
                 isMarketPlace: project.isMarketplace,
                 closeDate: project.closeDate,
+                stage: "Prospect",
               },
             ],
           }

--- a/api/useTerritories.tsx
+++ b/api/useTerritories.tsx
@@ -113,7 +113,10 @@ const fetchTerritories = async (): Promise<Territory[]> => {
     selectionSet,
   });
   if (errors) throw errors;
-  return data.map(mapTerritory);
+  return flow(
+    map(mapTerritory),
+    sortBy((t) => -t.latestQuota)
+  )(data);
 };
 
 const useTerritories = () => {
@@ -302,7 +305,6 @@ const useTerritory = (id: string | undefined) => {
   };
 
   const addTerritoryResponsibility = async (startDate: Date, quota: number) => {
-    console.log("addTerritoryResponsibility", { territory, startDate, quota });
     if (!territory) return;
     const { data, errors } = await client.models.TerritoryResponsibility.create(
       {
@@ -312,7 +314,6 @@ const useTerritory = (id: string | undefined) => {
       }
     );
     if (errors) handleApiErrors(errors, "Creating new responsibility failed");
-    console.log("addTerritoryResponsibility", { data, errors });
     return data?.id;
   };
 

--- a/api/useTerritories.tsx
+++ b/api/useTerritories.tsx
@@ -5,7 +5,7 @@ import {
   sortResponsibility,
 } from "@/components/responsibility-date-ranges/ResponsibilityDateRangeRecord";
 import { toast } from "@/components/ui/use-toast";
-import { toISODateString, usdCurrency } from "@/helpers/functional";
+import { formatRevenue, toISODateString } from "@/helpers/functional";
 import { SelectionSet, generateClient } from "aws-amplify/data";
 import { differenceInDays, format } from "date-fns";
 import { filter, first, flow, get, map, sortBy } from "lodash/fp";
@@ -29,14 +29,7 @@ type TerritoryData = SelectionSet<
   Schema["Territory"]["type"],
   typeof selectionSet
 >;
-
-type TerritoryAccountData = {
-  account: {
-    id: string;
-    name: string;
-    crmId?: string | null;
-  };
-};
+type TerritoryAccountData = TerritoryData["accounts"][number];
 
 type TerritoryAccount = {
   id: string;
@@ -75,7 +68,7 @@ export const makeCurrentResponsibilityText = (territory: Territory) =>
           !endDate
             ? `Since ${format(startDate, "PPP")}`
             : `${format(startDate, "PPP")} - ${format(endDate, "PPP")}`
-        }${!quota ? "" : ` (Quota: ${usdCurrency.format(quota)})`}`
+        }${!quota ? "" : ` (Quota: ${formatRevenue(quota)})`}`
     )
     .join(", ");
 

--- a/components/accounts/AccountDetails.tsx
+++ b/components/accounts/AccountDetails.tsx
@@ -1,5 +1,5 @@
 import { Account, useAccountsContext } from "@/api/ContextAccounts";
-import { make2YearsRevenueText } from "@/api/useCrmProjects";
+import { make2YearsRevenueText } from "@/helpers/projects";
 import { FC, useState } from "react";
 import CrmLink from "../crm/CrmLink";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";

--- a/components/accounts/AccountDetails.tsx
+++ b/components/accounts/AccountDetails.tsx
@@ -1,4 +1,5 @@
 import { Account, useAccountsContext } from "@/api/ContextAccounts";
+import { make2YearsRevenueText } from "@/api/useCrmProjects";
 import { FC, useState } from "react";
 import CrmLink from "../crm/CrmLink";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
@@ -46,25 +47,22 @@ const AccountDetails: FC<AccountDetailsProps> = ({
   };
 
   return (
-    <div className="cursor-default m-2">
-      <div className="flex flex-col gap-1 text-sm mb-2">
-        <div className="flex flex-row gap-1 items-center">
-          <div>Name:</div>
-          <div>{account.name}</div>
-          {account.crmId && <CrmLink category="Account" id={account.crmId} />}
-        </div>
-        {account.controller && (
-          <div>{`Parent account: ${account.controller?.name}`}</div>
-        )}
-        <ListTerritories territoryIds={account.territoryIds} />
-        <ListPayerAccounts
-          payerAccounts={account.payerAccounts}
-          deletePayerAccount={deletePayerAccount}
-        />
-      </div>
+    <>
       <AccountUpdateForm
         account={account}
         onUpdate={(props) => updateAccount({ id: account.id, ...props })}
+      />
+      <div>
+        Name: {account.name}{" "}
+        {account.crmId && <CrmLink category="Account" id={account.crmId} />}
+      </div>
+      {account.controller && (
+        <div>{`Parent account: ${account.controller?.name}`}</div>
+      )}
+      <ListTerritories territoryIds={account.territoryIds} />
+      <ListPayerAccounts
+        payerAccounts={account.payerAccounts}
+        deletePayerAccount={deletePayerAccount}
       />
 
       <Accordion
@@ -112,6 +110,11 @@ const AccountDetails: FC<AccountDetailsProps> = ({
         <DefaultAccordionItem
           value="Projects"
           triggerTitle="Projects"
+          triggerSubTitle={
+            account.pipeline === 0
+              ? ""
+              : make2YearsRevenueText(account.pipeline)
+          }
           isVisible={!!showProjects}
           accordionSelectedValue={accordionValue}
         >
@@ -136,7 +139,7 @@ const AccountDetails: FC<AccountDetailsProps> = ({
           <AccountNotes accountId={account.id} />
         </DefaultAccordionItem>
       </Accordion>
-    </div>
+    </>
   );
 };
 

--- a/components/accounts/AccountUpdateForm.tsx
+++ b/components/accounts/AccountUpdateForm.tsx
@@ -1,5 +1,6 @@
 import { Account, useAccountsContext } from "@/api/ContextAccounts";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Edit } from "lucide-react";
 import { FC, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -88,9 +89,7 @@ const AccountUpdateForm: FC<AccountUpdateFormProps> = ({
       <form>
         <Dialog open={formOpen} onOpenChange={onOpenChange}>
           <DialogTrigger asChild>
-            <Button size="sm" className="text-xs">
-              Edit
-            </Button>
+            <Edit className="w-5 h-5 text-muted-foreground hover:text-primary" />
           </DialogTrigger>
           <DialogContent>
             <DialogHeader>

--- a/components/accounts/AccountsList.tsx
+++ b/components/accounts/AccountsList.tsx
@@ -1,19 +1,5 @@
-import { Account, useAccountsContext } from "@/api/ContextAccounts";
-import {
-  DndContext,
-  DragEndEvent,
-  PointerSensor,
-  closestCenter,
-  useSensor,
-  useSensors,
-} from "@dnd-kit/core";
-import {
-  SortableContext,
-  arrayMove,
-  verticalListSortingStrategy,
-} from "@dnd-kit/sortable";
-import { flow } from "lodash/fp";
-import { FC, useEffect, useState } from "react";
+import { Account } from "@/api/ContextAccounts";
+import { FC, useState } from "react";
 import { Accordion } from "../ui/accordion";
 import AccountRecord from "./account-record";
 
@@ -27,18 +13,6 @@ type AccountsListProps = {
   showSubsidaries?: boolean;
 };
 
-const getSortedAccounts = (accounts: Account[], controllerId?: string) =>
-  accounts
-    .filter(
-      ({ controller }) =>
-        !controllerId || (controller && controller.id === controllerId)
-    )
-    .sort((a, b) =>
-      a.order === b.order
-        ? a.createdAt.getTime() - b.createdAt.getTime()
-        : b.order - a.order
-    );
-
 const AccountsList: FC<AccountsListProps> = ({
   accounts,
   controllerId,
@@ -48,42 +22,21 @@ const AccountsList: FC<AccountsListProps> = ({
   showProjects,
   showSubsidaries = true,
 }) => {
-  const { updateOrder } = useAccountsContext();
-  const [items, setItems] = useState(getSortedAccounts(accounts, controllerId));
   const [selectedAccount, setSelectedAccount] = useState<string | undefined>(
     undefined
   );
-  const sensors = useSensors(
-    useSensor(PointerSensor, {
-      activationConstraint: { delay: 250, tolerance: 5 },
-    })
-  );
 
-  useEffect(
-    () => setItems(getSortedAccounts(accounts, controllerId)),
-    [accounts, controllerId]
-  );
-
-  const updateOrderNumbers = (list: Account[]): Account[] =>
-    list.map((account, idx) => ({
-      ...account,
-      order: (list.length - idx) * 10,
-    }));
-
-  const moveItem = (items: Account[], oldIndex: number) => (newIndex: number) =>
-    arrayMove(items, oldIndex, newIndex);
-
-  const handleDragEnd = async ({ active, over }: DragEndEvent) => {
-    if (!over) return;
-    if (active.id === over.id) return;
-    const oldIndex = items.findIndex((item) => item.id === active.id);
-    const newIndex = items.findIndex((item) => item.id === over.id);
-
-    flow(moveItem(items, oldIndex), updateOrderNumbers, updateOrder)(newIndex);
-  };
-
-  return items.length === 0 ? (
-    "No accounts"
+  return !accounts ? (
+    "Loading accounts…"
+  ) : accounts.filter(
+      ({ controller }) =>
+        !controllerId || (controller && controller.id === controllerId)
+    ).length === 0 ? (
+    !controllerId ? (
+      "No accounts"
+    ) : (
+      "No subsidiaries"
+    )
   ) : (
     <Accordion
       type="single"
@@ -93,29 +46,23 @@ const AccountsList: FC<AccountsListProps> = ({
         setSelectedAccount(val === selectedAccount ? undefined : val)
       }
     >
-      <DndContext
-        sensors={sensors}
-        collisionDetection={closestCenter}
-        onDragEnd={handleDragEnd}
-      >
-        <SortableContext items={items} strategy={verticalListSortingStrategy}>
-          <div>
-            {items.map((account) => (
-              <AccountRecord
-                key={account.id}
-                account={account}
-                className="px-2"
-                selectedAccordionItem={selectedAccount}
-                showContacts={showContacts}
-                showIntroduction={showIntroduction}
-                showNotes={showNotes}
-                showProjects={showProjects}
-                showSubsidaries={showSubsidaries}
-              />
-            ))}
-          </div>
-        </SortableContext>
-      </DndContext>
+      {accounts
+        .filter(
+          ({ controller }) =>
+            !controllerId || (controller && controller.id === controllerId)
+        )
+        .map((account) => (
+          <AccountRecord
+            key={account.id}
+            account={account}
+            selectedAccordionItem={selectedAccount}
+            showContacts={showContacts}
+            showIntroduction={showIntroduction}
+            showNotes={showNotes}
+            showProjects={showProjects}
+            showSubsidaries={showSubsidaries}
+          />
+        ))}
     </Accordion>
   );
 };

--- a/components/accounts/ListPayerAccounts.tsx
+++ b/components/accounts/ListPayerAccounts.tsx
@@ -19,10 +19,13 @@ const ListPayerAccounts: FC<ListPayerAccountsProps> = ({
   showLinks = true,
 }) =>
   payerAccounts.length > 0 && (
-    <div>
-      {showLabel && "Payer accounts:"}
+    <>
+      <div>{showLabel && "Payer accounts:"}</div>
       {payerAccounts.map((payer) => (
-        <div key={payer} className="flex flex-row gap-1 text-sm items-center">
+        <div
+          key={payer}
+          className="flex flex-row gap-1 text-sm items-center text-muted-foreground"
+        >
           {payer}
           {showLinks && (
             <>
@@ -57,7 +60,7 @@ const ListPayerAccounts: FC<ListPayerAccountsProps> = ({
           )}
         </div>
       ))}
-    </div>
+    </>
   );
 
 export default ListPayerAccounts;

--- a/components/accounts/ListTerritories.tsx
+++ b/components/accounts/ListTerritories.tsx
@@ -1,4 +1,7 @@
 import useTerritories, { Territory } from "@/api/useTerritories";
+import { formatRevenue } from "@/helpers/functional";
+import { ExternalLinkIcon } from "lucide-react";
+import Link from "next/link";
 import { FC } from "react";
 import CrmLink from "../crm/CrmLink";
 
@@ -7,8 +10,14 @@ type RenderTerritoryProps = {
 };
 const RenderTerritory: FC<RenderTerritoryProps> = ({ territory }) =>
   territory && (
-    <div className="flex flex-row gap-1 text-sm items-center">
+    <div className="flex flex-row gap-1 text-sm items-center text-muted-foreground">
       {territory.name}
+      {territory.latestQuota === 0
+        ? ""
+        : ` (${formatRevenue(territory.latestQuota)})`}
+      <Link href={`/territories/${territory.id}`}>
+        <ExternalLinkIcon className="h-4 w-4 text-muted-foreground hover:text-primary" />
+      </Link>
       {territory.crmId && (
         <CrmLink category="Territory__c" id={territory.crmId} />
       )}
@@ -24,15 +33,15 @@ const ListTerritories: FC<ListTerritoriesProps> = ({ territoryIds }) => {
 
   return (
     territoryIds.length > 0 && (
-      <div>
-        Assigned territories:
+      <>
+        <div>Assigned territories:</div>
         {territoryIds.map((id) => (
           <RenderTerritory
             key={id}
             territory={territories?.find((t) => t.id === id)}
           />
         ))}
-      </div>
+      </>
     )
   );
 };

--- a/components/accounts/ProjectList.tsx
+++ b/components/accounts/ProjectList.tsx
@@ -1,10 +1,8 @@
-import { Account, useAccountsContext } from "@/api/ContextAccounts";
-import { Project, useProjectsContext } from "@/api/ContextProjects";
-import { getRevenue2Years } from "@/api/useCrmProjects";
-import { isTodayOrFuture } from "@/helpers/functional";
-import { filter, flow, get, map, sortBy, sum } from "lodash/fp";
+import { useAccountsContext } from "@/api/ContextAccounts";
+import { useProjectsContext } from "@/api/ContextProjects";
+import { filterAndSortProjects, getRevenue2Years } from "@/helpers/projects";
 import Link from "next/link";
-import { FC, useEffect, useState } from "react";
+import { FC, useState } from "react";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
 import ProjectDetails from "../ui-elements/project-details/project-details";
 import { Accordion } from "../ui/accordion";
@@ -26,68 +24,19 @@ type ProjectsByFilter = {
 };
 type ProjectListProps = ProjectsByAccount | ProjectsByFilter;
 
-type FilterProjectsProps = {
-  projects?: Project[];
-  accountId?: string;
-  filter?: ProjectFilters;
-  accounts?: Account[];
-};
-
-const filterAccounts = (project: Project) => (account: Account) =>
-  project.accountIds.includes(account.id);
-
-const calcPriority = (accounts?: Account[]) => (project: Project) => ({
-  ...project,
-  priority:
-    flow(filter(filterAccounts(project)), map(get("priority")), sum)(accounts) *
-      10 +
-    project.priority,
-});
-
-const filterProject =
-  ({ filter, accountId }: FilterProjectsProps) =>
-  ({ accountIds, done, onHoldTill }: Project) =>
-    accountId
-      ? accountIds.includes(accountId)
-      : (filter === "WIP" &&
-          !done &&
-          (!onHoldTill || !isTodayOrFuture(onHoldTill))) ||
-        (filter === "On Hold" &&
-          !done &&
-          onHoldTill &&
-          isTodayOrFuture(onHoldTill)) ||
-        (filter === "Done" && done);
-
-const filterProjects = ({
-  projects,
-  filter: statusFilter,
+const ProjectList: FC<ProjectListProps> = ({
   accountId,
-  accounts,
-}: FilterProjectsProps) =>
-  flow(
-    filter(filterProject({ accountId, filter: statusFilter })),
-    map(calcPriority(accounts)),
-    sortBy((p) => -p.priority)
-  )(projects);
-
-const ProjectList: FC<ProjectListProps> = ({ accountId, filter }) => {
+  filter: projectFilter,
+}) => {
   const { projects } = useProjectsContext();
   const { accounts, getAccountById } = useAccountsContext();
-  const [items, setItems] = useState<Project[] | undefined>(
-    filterProjects({ projects, accountId, filter, accounts })
-  );
   const [accordionValue, setAccordionValue] = useState<string | undefined>(
     undefined
   );
 
-  useEffect(
-    () => setItems(filterProjects({ projects, accountId, filter, accounts })),
-    [accountId, projects, filter, accounts]
-  );
-
-  return !items ? (
+  return !projects ? (
     "Loading…"
-  ) : items.length === 0 ? (
+  ) : projects.length === 0 ? (
     "No projects"
   ) : (
     <Accordion
@@ -98,38 +47,42 @@ const ProjectList: FC<ProjectListProps> = ({ accountId, filter }) => {
         setAccordionValue(val === accordionValue ? undefined : val)
       }
     >
-      {items.map(({ id: projectId, project, accountIds, crmProjects }) => (
-        <DefaultAccordionItem
-          key={projectId}
-          value={projectId}
-          triggerTitle={project}
-          className="tracking-tight"
-          accordionSelectedValue={accordionValue}
-          link={`/projects/${projectId}`}
-          triggerSubTitle={
-            <>
-              {accountIds.map((id: string) => (
-                <Link
-                  key={id}
-                  className="hover:underline truncate"
-                  href={`/accounts/${id}`}
-                >
-                  {getAccountById(id)?.name}
-                </Link>
-              ))}
-              {crmProjects.length > 0 && (
-                <div className="truncate">{getRevenue2Years(crmProjects)}</div>
-              )}
-            </>
-          }
-        >
-          <ProjectDetails
-            projectId={projectId}
-            showCrmDetails
-            includeAccounts
-          />
-        </DefaultAccordionItem>
-      ))}
+      {filterAndSortProjects(projects, accountId, projectFilter, accounts).map(
+        ({ id: projectId, project, accountIds, crmProjects }) => (
+          <DefaultAccordionItem
+            key={projectId}
+            value={projectId}
+            triggerTitle={project}
+            className="tracking-tight"
+            accordionSelectedValue={accordionValue}
+            link={`/projects/${projectId}`}
+            triggerSubTitle={
+              <>
+                {accountIds.map((id: string) => (
+                  <Link
+                    key={id}
+                    className="hover:underline truncate"
+                    href={`/accounts/${id}`}
+                  >
+                    {getAccountById(id)?.name}
+                  </Link>
+                ))}
+                {crmProjects.length > 0 && (
+                  <div className="truncate">
+                    {getRevenue2Years(crmProjects)}
+                  </div>
+                )}
+              </>
+            }
+          >
+            <ProjectDetails
+              projectId={projectId}
+              showCrmDetails
+              includeAccounts
+            />
+          </DefaultAccordionItem>
+        )
+      )}
     </Accordion>
   );
 };

--- a/components/accounts/ProjectList.tsx
+++ b/components/accounts/ProjectList.tsx
@@ -87,6 +87,8 @@ const ProjectList: FC<ProjectListProps> = ({ accountId, filter }) => {
 
   return !items ? (
     "Loading…"
+  ) : items.length === 0 ? (
+    "No projects"
   ) : (
     <Accordion
       type="single"

--- a/components/accounts/account-record.tsx
+++ b/components/accounts/account-record.tsx
@@ -1,14 +1,12 @@
 import { Account, useAccountsContext } from "@/api/ContextAccounts";
 import useTerritories from "@/api/useTerritories";
-import { useSortable } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
+import { formatRevenue } from "@/helpers/functional";
 import { FC } from "react";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
 import AccountDetails from "./AccountDetails";
 
 type AccountRecordProps = {
   account: Account;
-  className?: string;
   selectedAccordionItem?: string;
   showContacts?: boolean;
   showIntroduction?: boolean;
@@ -19,7 +17,6 @@ type AccountRecordProps = {
 
 const AccountRecord: FC<AccountRecordProps> = ({
   account,
-  className,
   selectedAccordionItem,
   showContacts,
   showIntroduction,
@@ -29,24 +26,20 @@ const AccountRecord: FC<AccountRecordProps> = ({
 }) => {
   const { territories } = useTerritories();
   const { accounts } = useAccountsContext();
-  const { attributes, listeners, setNodeRef, transform, transition } =
-    useSortable({ id: account.id });
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  };
 
   return (
     <DefaultAccordionItem
       value={account.id}
-      ref={setNodeRef}
-      style={style}
-      className={className}
       triggerTitle={account.name}
       triggerSubTitle={[
         ...(territories
           ?.filter((t) => account.territoryIds.includes(t.id))
-          .map((t) => t.name) || []),
+          .map(
+            (t): string =>
+              `${t.name}${
+                t.latestQuota === 0 ? "" : ` (${formatRevenue(t.latestQuota)})`
+              }`
+          ) || []),
         ...(accounts
           ?.filter((a) => account.id === a.controller?.id)
           .map((a) => a.name) || []),
@@ -55,8 +48,6 @@ const AccountRecord: FC<AccountRecordProps> = ({
         .join(", ")}
       link={`/accounts/${account.id}`}
       accordionSelectedValue={selectedAccordionItem}
-      {...attributes}
-      {...listeners}
     >
       <AccountDetails
         account={account}

--- a/components/navigation-menu/NavigationMenu.tsx
+++ b/components/navigation-menu/NavigationMenu.tsx
@@ -3,7 +3,6 @@ import { useProjectsContext } from "@/api/ContextProjects";
 import usePeople from "@/api/usePeople";
 import { useContextContext } from "@/contexts/ContextContext";
 import { useNavMenuContext } from "@/contexts/NavMenuContext";
-import { useCommandState } from "cmdk";
 import { Plus } from "lucide-react";
 import { useRouter } from "next/router";
 import { BiConversation } from "react-icons/bi";
@@ -23,6 +22,7 @@ import {
 } from "../ui/command";
 import Version from "../version/version";
 import ContextSwitcher from "./ContextSwitcher";
+import SearchableDataGroup from "./SearchableDataGroup";
 
 type NavigationItem = {
   label: string;
@@ -73,78 +73,6 @@ const NavigationMenu = () => {
     { label: "Inbox", url: "/inbox", shortcut: "^I" },
   ];
 
-  const Projects = () => {
-    const search = useCommandState((state) => state.search);
-    if (!search) return null;
-    if (!projects) return null;
-    return (
-      <CommandGroup heading="Projects">
-        {projects.map((p) => (
-          <CommandItem
-            key={p.id}
-            value={`${p.project} ${accounts
-              ?.filter((a) => p.accountIds.includes(a.id))
-              .map((a) => a.name)
-              .join(", ")}`}
-            onSelect={() => {
-              router.push(`/projects/${p.id}`);
-              toggleMenu();
-            }}
-          >
-            {p.project} (
-            {accounts
-              ?.filter((a) => p.accountIds.includes(a.id))
-              .map((a) => a.name)
-              .join(", ")}
-            )
-          </CommandItem>
-        ))}
-      </CommandGroup>
-    );
-  };
-
-  const People = () => {
-    const search = useCommandState((state) => state.search);
-    if (!search) return null;
-    if (!people) return null;
-    return (
-      <CommandGroup heading="People">
-        {people.map((p) => (
-          <CommandItem
-            key={p.id}
-            onSelect={() => {
-              router.push(`/people/${p.id}`);
-              toggleMenu();
-            }}
-          >
-            {p.name}
-          </CommandItem>
-        ))}
-      </CommandGroup>
-    );
-  };
-
-  const Accounts = () => {
-    const search = useCommandState((state) => state.search);
-    if (!search) return null;
-    if (!accounts) return null;
-    return (
-      <CommandGroup heading="Accounts">
-        {accounts.map((a) => (
-          <CommandItem
-            key={a.id}
-            onSelect={() => {
-              router.push(`/accounts/${a.id}`);
-              toggleMenu();
-            }}
-          >
-            {a.name}
-          </CommandItem>
-        ))}
-      </CommandGroup>
-    );
-  };
-
   return (
     <CommandDialog open={menuIsOpen} onOpenChange={toggleMenu}>
       <CommandInput placeholder="Type a command or search…" />
@@ -186,9 +114,35 @@ const NavigationMenu = () => {
             </CommandItem>
           ))}
         </CommandGroup>
-        <Projects />
-        <Accounts />
-        <People />
+        <SearchableDataGroup
+          heading="Accounts"
+          items={accounts?.map(({ id, name }) => ({
+            id,
+            value: name,
+            link: `/accounts/${id}`,
+          }))}
+        />
+        <SearchableDataGroup
+          heading="People"
+          items={people?.map(({ id, name }) => ({
+            id,
+            value: name,
+            link: `/people/${id}`,
+          }))}
+        />
+        <SearchableDataGroup
+          heading="Projects"
+          items={projects
+            ?.filter((p) => !p.done)
+            .map(({ id, project, accountIds }) => ({
+              id,
+              value: `${project} (${accounts
+                ?.filter((a) => accountIds.includes(a.id))
+                .map((a) => a.name)
+                .join(", ")})`,
+              link: `/projects/${id}`,
+            }))}
+        />
         <CommandItem forceMount onSelect={openCreateInboxItemDialog}>
           <Plus className="mr-2 h-4 w-4" />
           <span>Create Inbox Item</span>

--- a/components/navigation-menu/SearchableDataGroup.tsx
+++ b/components/navigation-menu/SearchableDataGroup.tsx
@@ -1,0 +1,45 @@
+import { useNavMenuContext } from "@/contexts/NavMenuContext";
+import { useCommandState } from "cmdk";
+import { useRouter } from "next/router";
+import { FC } from "react";
+import { CommandGroup, CommandItem } from "../ui/command";
+
+type SearchableDataGroupProps = {
+  heading: string;
+  items?: {
+    id: string;
+    value: string;
+    link: string;
+  }[];
+};
+
+const SearchableDataGroup: FC<SearchableDataGroupProps> = ({
+  heading,
+  items,
+}) => {
+  const router = useRouter();
+  const { toggleMenu } = useNavMenuContext();
+  const search = useCommandState((state) => state.search);
+
+  return (
+    search &&
+    search.length >= 4 &&
+    items && (
+      <CommandGroup heading={heading}>
+        {items.map(({ id, value, link }) => (
+          <CommandItem
+            key={id}
+            onSelect={() => {
+              router.push(link);
+              toggleMenu();
+            }}
+          >
+            {value}
+          </CommandItem>
+        ))}
+      </CommandGroup>
+    )
+  );
+};
+
+export default SearchableDataGroup;

--- a/components/responsibility-date-ranges/ResponsibilityDateRangeRecord.tsx
+++ b/components/responsibility-date-ranges/ResponsibilityDateRangeRecord.tsx
@@ -1,4 +1,4 @@
-import { usdCurrency } from "@/helpers/functional";
+import { formatRevenue } from "@/helpers/functional";
 import { addDays, format } from "date-fns";
 import { flow, get, last, map, reduce, sortBy } from "lodash/fp";
 import { Trash2 } from "lucide-react";
@@ -79,7 +79,7 @@ const ResponsibilityDateRangeRecord: FC<ResponsibilityDateRangeRecordProps> = ({
       .join(" and ")}. ${
       !responsibility.quota
         ? ""
-        : `(Quota: ${usdCurrency.format(responsibility.quota)})`
+        : `(Quota: ${formatRevenue(responsibility.quota)})`
     }`}
     <Button
       variant="ghost"

--- a/components/territories/TerritoryDetails.tsx
+++ b/components/territories/TerritoryDetails.tsx
@@ -3,7 +3,7 @@ import {
   makeCurrentResponsibilityText,
   useTerritory,
 } from "@/api/useTerritories";
-import { usdCurrency } from "@/helpers/functional";
+import { formatRevenue } from "@/helpers/functional";
 import { format } from "date-fns";
 import { FC, useState } from "react";
 import AccountsList from "../accounts/AccountsList";
@@ -33,28 +33,25 @@ const TerritoryDetails: FC<TerritoryDetailsProps> = ({
     "Loading territory…"
   ) : (
     <>
-      <div className="flex flex-col gap-1 text-sm">
-        <div>
-          {`Name: ${territory.name}`}
-          {territory.crmId && (
-            <CrmLink category="Territory__c" id={territory.crmId} />
-          )}
-        </div>
-        {territory.latestQuota > 0 && (
-          <div>{`Quota: ${usdCurrency.format(territory.latestQuota)}`}</div>
+      <TerritoryUpdateForm
+        territory={territory}
+        onUpdate={({ crmId, name, quota, responsibleSince }) =>
+          updateTerritory({ name, crmId, responsibleSince, quota })
+        }
+      />
+      <div>
+        Name: {territory.name}{" "}
+        {territory.crmId && (
+          <CrmLink category="Territory__c" id={territory.crmId} />
         )}
-        <div>{`Responsible since: ${format(
-          territory.latestResponsibilityStarted,
-          "PPP"
-        )}`}</div>
-        <TerritoryUpdateForm
-          territory={territory}
-          onUpdate={({ crmId, name, quota, responsibleSince }) =>
-            updateTerritory({ name, crmId, responsibleSince, quota })
-          }
-        />
       </div>
-      <div className="mt-8" />
+      {territory.latestQuota > 0 && (
+        <div>Quota: {formatRevenue(territory.latestQuota)}</div>
+      )}
+      <div>
+        Responsible since:{" "}
+        {format(territory.latestResponsibilityStarted, "PPP")}
+      </div>
 
       <Accordion
         type="single"

--- a/components/territories/TerritoryUpdateForm.tsx
+++ b/components/territories/TerritoryUpdateForm.tsx
@@ -1,6 +1,7 @@
 import { Territory } from "@/api/useTerritories";
 import { revenueNumber } from "@/helpers/ui-form-helpers";
 import { zodResolver } from "@hookform/resolvers/zod";
+import { Edit } from "lucide-react";
 import { FC, useEffect, useState } from "react";
 import { useForm } from "react-hook-form";
 import { z } from "zod";
@@ -101,9 +102,7 @@ const TerritoryUpdateForm: FC<TerritoryUpdateFormProps> = ({
       <form>
         <Dialog open={formOpen} onOpenChange={onOpenChange}>
           <DialogTrigger asChild>
-            <Button size="sm" className="text-xs">
-              Edit
-            </Button>
+            <Edit className="w-5 h-5 text-muted-foreground hover:text-primary" />
           </DialogTrigger>
           <DialogContent>
             <DialogHeader>

--- a/components/ui-elements/crm-project-details/CrmProjectForm.tsx
+++ b/components/ui-elements/crm-project-details/CrmProjectForm.tsx
@@ -127,7 +127,10 @@ const CrmProjectForm: FC<CrmProjectFormProps> = ({
   const handleCreate = async (data: z.infer<typeof FormSchema>) => {
     if (!onCreate) return;
     setFormOpen(false);
-    const result = await onCreate(data);
+    const result = await onCreate({
+      ...data,
+      stage: CRM_STAGES.find((s) => s === data.stage) || "Prospect",
+    });
     if (!result) return;
     toast({
       title: "CRM Project created",
@@ -138,7 +141,10 @@ const CrmProjectForm: FC<CrmProjectFormProps> = ({
   const handleUpdate = async (data: z.infer<typeof FormSchema>) => {
     if (!onChange) return;
     setFormOpen(false);
-    const result = await onChange(data);
+    const result = await onChange({
+      ...data,
+      stage: CRM_STAGES.find((s) => s === data.stage) || "Prospect",
+    });
     if (!result) return;
     toast({
       title: "CRM Project updated",

--- a/components/ui-elements/crm-project-details/crm-project-details.tsx
+++ b/components/ui-elements/crm-project-details/crm-project-details.tsx
@@ -38,7 +38,7 @@ const CrmProjectDetails: FC<CrmProjectDetailsProps> = ({
       }
     >
       <CrmProjectForm crmProject={crmProject} onChange={updateCrmProject} />
-      Stage: {crmProject.stage}
+      <div>Stage: {crmProject.stage}</div>
       {crmProject.arr > 0 && (
         <div>Annual recurring revenue: {formatUsdCurrency(crmProject.arr)}</div>
       )}

--- a/components/ui-elements/crm-project-details/crm-project-details.tsx
+++ b/components/ui-elements/crm-project-details/crm-project-details.tsx
@@ -1,7 +1,7 @@
 import useCrmProject from "@/api/useCrmProject";
-import { getRevenue2Years } from "@/api/useCrmProjects";
 import { makeCrmLink } from "@/components/crm/CrmLink";
 import { formatUsdCurrency } from "@/helpers/functional";
+import { getRevenue2Years } from "@/helpers/projects";
 import { format } from "date-fns";
 import { FC } from "react";
 import DefaultAccordionItem from "../accordion/DefaultAccordionItem";

--- a/components/ui-elements/crm-project-details/crm-projects-list.tsx
+++ b/components/ui-elements/crm-project-details/crm-projects-list.tsx
@@ -1,8 +1,9 @@
 import { CrmProjectData } from "@/api/ContextProjects";
 import { CrmProjectOnChangeFields } from "@/api/useCrmProject";
-import useCrmProjects, { getRevenue2Years } from "@/api/useCrmProjects";
+import useCrmProjects from "@/api/useCrmProjects";
 import { Accordion } from "@/components/ui/accordion";
 import { useContextContext } from "@/contexts/ContextContext";
+import { getRevenue2Years } from "@/helpers/projects";
 import { FC, useState } from "react";
 import DefaultAccordionItem from "../accordion/DefaultAccordionItem";
 import CrmProjectForm from "./CrmProjectForm";

--- a/components/ui-elements/project-details/project-account-details.tsx
+++ b/components/ui-elements/project-details/project-account-details.tsx
@@ -17,15 +17,13 @@ const AccountName: FC<AccountNameProps> = ({
   accountName,
   removeAccount,
 }) => (
-  <div className="flex flex-row gap-2">
-    <div>
-      <Link href={`/accounts/${accountId}`} className="hover:underline">
-        {accountName}
-      </Link>
-    </div>
+  <div className="flex flex-row gap-2 items-center">
+    <Link href={`/accounts/${accountId}`} className="hover:underline">
+      {accountName}
+    </Link>
     {removeAccount && accountName && (
       <Trash2
-        className="pt-[0.1rem] pb-[0.4rem] text-muted-foreground hover:text-primary"
+        className="h-4 w-4 text-muted-foreground hover:text-primary"
         onClick={() => removeAccount(accountId, accountName)}
       />
     )}
@@ -71,6 +69,7 @@ const ProjectAccountDetails: FC<ProjectAccountDetailsProps> = ({
             removeAccount={onRemoveAccount}
           />
         ))}
+        <div className="mt-4" />
         <AccountSelector
           value=""
           allowCreateAccounts

--- a/components/ui-elements/project-details/project-dates.tsx
+++ b/components/ui-elements/project-details/project-dates.tsx
@@ -43,18 +43,14 @@ const ProjectDates: FC<ProjectDatesProps> = ({
     triggerTitle="Project Dates"
     accordionSelectedValue={accordionSelectedValue}
     isVisible
-    triggerSubTitle={
-      <>
-        {doneOn ? (
-          `Done on: ${format(doneOn, "PPP")}`
-        ) : (
-          <>
-            {dueOn && `Due: ${format(dueOn, "PPP")}`}
-            {onHoldTill && `On hold till: ${format(onHoldTill, "PPP")}`}
-          </>
-        )}
-      </>
-    }
+    triggerSubTitle={[
+      { label: "Done on", value: doneOn && format(doneOn, "PPP") },
+      { label: "Due on", value: dueOn && format(dueOn, "PPP") },
+      { label: "On hold till", value: onHoldTill && format(onHoldTill, "PPP") },
+    ]
+      .filter(({ value }) => !!value)
+      .map(({ label, value }) => `${label}: ${value}`)
+      .join(", ")}
   >
     <div className="space-y-4">
       <ProjectDatesHelper

--- a/components/ui-elements/project-notes-form/project-notes-form.tsx
+++ b/components/ui-elements/project-notes-form/project-notes-form.tsx
@@ -1,8 +1,8 @@
 import { useAccountsContext } from "@/api/ContextAccounts";
 import { Project, useProjectsContext } from "@/api/ContextProjects";
 import useActivity from "@/api/useActivity";
-import { getRevenue2Years } from "@/api/useCrmProjects";
 import { Accordion } from "@/components/ui/accordion";
+import { getRevenue2Years } from "@/helpers/projects";
 import Link from "next/link";
 import { FC, useState } from "react";
 import { debouncedUpdateNotes } from "../../activities/activity-helper";

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,1 +1,9 @@
-# In NavigationMenu das Durchsuchen von Projekten, Accounts und Personen anbieten (Version :VERSION)
+# Fehler bereinigen (Territorys und Accounts) (Version :VERSION)
+
+- Territorys werden nun nach Quota absteigend sortiert, damit das wichtigste Territory oben in der Liste erscheint.
+
+In Arbeit:
+
+- Accounts sind nun auch dann als gültig anerkannt, wenn zwar nicht der Account selbst Teil eines aktuellen Territorys ist, aber eine der Töchter. Dabei wird nur eine Ebene tief nach gültigen Territorys gesucht.
+- Accounts werden nach Quota absteigend sortiert und nach ihrer Order-Nummer.
+- Im Navigationsmenü werden nun maximal 4 Einträge für Projekte, Accounts und Personen angezeigt. Dabei werden zuerst Accounts, dann Personen und dann Projekte angezeigt.

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,9 +1,13 @@
-# Fehler bereinigen (Territorys und Accounts) (Version :VERSION)
+# Visuelle Fehler bereinigen (Territorys und Accounts) (Version :VERSION)
 
 - Territorys werden nun nach Quota absteigend sortiert, damit das wichtigste Territory oben in der Liste erscheint.
+- Quoten und Pipeline Summen werden nun abhängig nach Größe formatiert (z.B. $4,000 oder $450k oder $3.4M).
+- Accounts sind nun auch dann als aktuell relevant anerkannt, wenn zwar nicht der Account selbst Teil eines aktuellen Territorys ist, aber eine der Töchter. Dabei wird nur eine Ebene tief nach gültigen Territorys gesucht.
+- Accounts werden nach ihrer aktuellen Quote und der aktuellen Pipeline jeweils absteigend sortiert.
+- Die Detaildaten für CRM Projekte, Accounts und Territorys werden nun visuell einheitlich dargestellt.
+- Wenn bei einem Projekt ein "On Hold" Datum gesetzt ist, dieses aber in der Vergangenheit liegt, wird dieses ignoriert und somit auch nicht mehr bei den Projektdaten angezeigt.
+- Im Navigationsmenü werden nun zuerst Accounts, dann Personen und dann Projekte angezeigt. Es werden ausschließlich offene Projekte angezeigt.
 
 In Arbeit:
 
-- Accounts sind nun auch dann als gültig anerkannt, wenn zwar nicht der Account selbst Teil eines aktuellen Territorys ist, aber eine der Töchter. Dabei wird nur eine Ebene tief nach gültigen Territorys gesucht.
-- Accounts werden nach Quota absteigend sortiert und nach ihrer Order-Nummer.
-- Im Navigationsmenü werden nun maximal 4 Einträge für Projekte, Accounts und Personen angezeigt. Dabei werden zuerst Accounts, dann Personen und dann Projekte angezeigt.
+- Projekte werden nach Wichtigkeit der Accounts und des Projektvolumens sortiert.

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -7,7 +7,4 @@
 - Die Detaildaten für CRM Projekte, Accounts und Territorys werden nun visuell einheitlich dargestellt.
 - Wenn bei einem Projekt ein "On Hold" Datum gesetzt ist, dieses aber in der Vergangenheit liegt, wird dieses ignoriert und somit auch nicht mehr bei den Projektdaten angezeigt.
 - Im Navigationsmenü werden nun zuerst Accounts, dann Personen und dann Projekte angezeigt. Es werden ausschließlich offene Projekte angezeigt.
-
-In Arbeit:
-
 - Projekte werden nach Wichtigkeit der Accounts und des Projektvolumens sortiert.

--- a/helpers/accounts.ts
+++ b/helpers/accounts.ts
@@ -1,0 +1,36 @@
+import { AccountData } from "@/api/ContextAccounts";
+import { differenceInDays } from "date-fns";
+import { find, flow, get, map, max, sortBy, sum } from "lodash/fp";
+
+type TerritoryData = AccountData["territories"][number];
+type SubsidiaryData = AccountData["subsidiaries"][number];
+type ResponsibilityData =
+  TerritoryData["territory"]["responsibilities"][number];
+
+const getLatestQuota = (territories: TerritoryData[]) =>
+  flow(
+    map(
+      (t: TerritoryData) =>
+        flow(
+          sortBy((r: ResponsibilityData) => -new Date(r.startDate).getTime()),
+          find((r) => differenceInDays(new Date(), new Date(r.startDate)) > 0),
+          get("quota")
+        )(t.territory.responsibilities) || 0
+    ),
+    sum
+  )(territories);
+
+export const getQuotaFromTerritoryOrSubsidaries = (
+  territories: TerritoryData[],
+  subsidiaries: SubsidiaryData[]
+) =>
+  max([
+    getLatestQuota(territories),
+    flow(
+      map((s: SubsidiaryData) => getLatestQuota(s.territories)),
+      sum
+    )(subsidiaries),
+  ]) || 0;
+
+export const calcOrder = (quota: number, pipeline: number): number =>
+  sum([Math.floor(quota / 1000) * 1000, Math.floor(pipeline / 1000)]);

--- a/helpers/functional.ts
+++ b/helpers/functional.ts
@@ -26,9 +26,20 @@ export const isTodayOrFuture = (date: string | Date): boolean => {
   today.setHours(0, 0, 0, 0);
   return inputDate.getTime() >= today.getTime();
 };
-export const usdCurrency = new Intl.NumberFormat(undefined, {
+export const usdCurrency = new Intl.NumberFormat("en-US", {
   currency: "USD",
   style: "currency",
   maximumFractionDigits: 0,
 });
 export const formatUsdCurrency = (val: number) => usdCurrency.format(val);
+export const formatRevenue = (revenue: number) =>
+  revenue < 5000
+    ? new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        minimumFractionDigits: 0,
+        maximumFractionDigits: 0,
+      }).format(revenue)
+    : revenue < 500000
+    ? `$${(revenue / 1000).toFixed(0)}k`
+    : `$${(revenue / 1000000).toFixed(1)}M`;

--- a/helpers/projects.ts
+++ b/helpers/projects.ts
@@ -1,0 +1,95 @@
+import { Account, calcOrder } from "@/api/ContextAccounts";
+import { CrmDataProps, Project, mapCrmData } from "@/api/ContextProjects";
+import { STAGES_PROBABILITY, TCrmStages } from "@/api/useCrmProject";
+import { ProjectFilters } from "@/components/accounts/ProjectList";
+import { differenceInCalendarMonths } from "date-fns";
+import { filter, flatMap, flow, get, map, max, round, sum } from "lodash/fp";
+import { formatRevenue } from "./functional";
+
+interface CalcPipelineProps {
+  projects: {
+    crmProjects: CrmDataProps[];
+  };
+}
+
+export interface ICalcRevenueTwoYears {
+  arr: number;
+  tcv: number;
+  closeDate: Date;
+  isMarketPlace?: boolean;
+  stage: TCrmStages;
+}
+
+export const calcProjectOrder =
+  (pipeline: number) => (accountQuota: number | undefined) =>
+    calcOrder(accountQuota || 0, pipeline);
+
+const maxOfArray = (val: number[]): number => max(val) || 0;
+
+export const getProbability = (stage: string): number =>
+  (STAGES_PROBABILITY.find((s) => s.stage === stage)?.probability || 0) / 100;
+
+export const calcRevenueTwoYears = (crmProject: ICalcRevenueTwoYears) =>
+  flow(
+    ({
+      arr,
+      tcv,
+      closeDate,
+      isMarketPlace,
+      stage,
+    }: ICalcRevenueTwoYears): number[] => [
+      (arr / 12) *
+        (24 - differenceInCalendarMonths(closeDate, new Date())) *
+        getProbability(stage),
+      (tcv / (isMarketPlace ? 2 : 1)) * getProbability(stage),
+    ],
+    maxOfArray,
+    round
+  )(crmProject);
+
+export const calcPipeline = (projects: CalcPipelineProps[]): number =>
+  flow(
+    map(get("projects")),
+    map(get("crmProjects")),
+    flatMap(map(mapCrmData)),
+    map(calcRevenueTwoYears),
+    sum,
+    (val: number | undefined) => (!val ? 0 : val / 1000),
+    Math.floor
+  )(projects);
+
+export const updateProjectOrder =
+  (accounts: Account[] | undefined) => (project: Project) => ({
+    ...project,
+    order: flow(
+      filter((a: Account) => project.accountIds.includes(a.id)),
+      map(get("latestQuota")),
+      max,
+      calcProjectOrder(project.order)
+    )(accounts),
+  });
+
+export const make2YearsRevenueText = (revenue: number) =>
+  `Revenue next 2Ys: ${formatRevenue(revenue)}`;
+
+export const getRevenue2Years = (projects: ICalcRevenueTwoYears[]) =>
+  make2YearsRevenueText(flow(map(calcRevenueTwoYears), sum)(projects));
+
+export const filterByProjectStatus =
+  (accountId: string | undefined, projectFilter: ProjectFilters | undefined) =>
+  ({ accountIds, done, onHoldTill }: Project) =>
+    accountId
+      ? accountIds.includes(accountId)
+      : (projectFilter === "WIP" && !done && !onHoldTill) ||
+        (projectFilter === "On Hold" && !done && onHoldTill) ||
+        (projectFilter === "Done" && done);
+
+export const filterAndSortProjects = (
+  projects: Project[],
+  accountId: string | undefined,
+  projectFilter: ProjectFilters | undefined,
+  accounts: Account[] | undefined
+) =>
+  projects
+    .filter(filterByProjectStatus(accountId, projectFilter))
+    .map(updateProjectOrder(accounts));

--- a/helpers/projects.ts
+++ b/helpers/projects.ts
@@ -1,9 +1,10 @@
-import { Account, calcOrder } from "@/api/ContextAccounts";
+import { Account } from "@/api/ContextAccounts";
 import { CrmDataProps, Project, mapCrmData } from "@/api/ContextProjects";
 import { STAGES_PROBABILITY, TCrmStages } from "@/api/useCrmProject";
 import { ProjectFilters } from "@/components/accounts/ProjectList";
 import { differenceInCalendarMonths } from "date-fns";
 import { filter, flatMap, flow, get, map, max, round, sum } from "lodash/fp";
+import { calcOrder } from "./accounts";
 import { formatRevenue } from "./functional";
 
 interface CalcPipelineProps {

--- a/pages/accounts/[id].tsx
+++ b/pages/accounts/[id].tsx
@@ -50,7 +50,7 @@ const AccountDetailPage = () => {
       {!account ? (
         "Loading account..."
       ) : (
-        <div>
+        <div className="px-2 md:px-4">
           <SavedState saved={accountNameSaved} />
           <AccountDetails
             account={account}

--- a/pages/accounts/index.tsx
+++ b/pages/accounts/index.tsx
@@ -1,5 +1,4 @@
 import { useAccountsContext } from "@/api/ContextAccounts";
-import useTerritories from "@/api/useTerritories";
 import AccountsList from "@/components/accounts/AccountsList";
 import MainLayout from "@/components/layouts/MainLayout";
 import {
@@ -12,7 +11,6 @@ import { useRouter } from "next/router";
 
 const AccountsListPage = () => {
   const { accounts, createAccount } = useAccountsContext();
-  const { territories } = useTerritories();
   const router = useRouter();
 
   const createAndOpenNewAccount = async () => {
@@ -31,16 +29,10 @@ const AccountsListPage = () => {
         "Loading accounts…"
       ) : (
         <div>
-          <div className="text-left md:text-center">
-            Drag to change the priority of your accounts.
-          </div>
           <AccountsList
+            showProjects
             accounts={accounts.filter(
-              (a) =>
-                !a.controller &&
-                territories?.some(
-                  (t) => t.latestQuota > 0 && a.territoryIds.includes(t.id)
-                )
+              (a) => !a.controller && a.latestQuota > 0
             )}
           />
           <div className="mt-8" />
@@ -52,12 +44,7 @@ const AccountsListPage = () => {
               <AccordionContent>
                 <AccountsList
                   accounts={accounts.filter(
-                    (a) =>
-                      !a.controller &&
-                      !territories?.some(
-                        (t) =>
-                          t.latestQuota > 0 && a.territoryIds.includes(t.id)
-                      )
+                    (a) => !a.controller && a.latestQuota === 0
                   )}
                 />
               </AccordionContent>


### PR DESCRIPTION
# Visuelle Fehler bereinigen (Territorys und Accounts)

- Territorys werden nun nach Quota absteigend sortiert, damit das wichtigste Territory oben in der Liste erscheint.
- Quoten und Pipeline Summen werden nun abhängig nach Größe formatiert (z.B. $4,000 oder $450k oder $3.4M).
- Accounts sind nun auch dann als aktuell relevant anerkannt, wenn zwar nicht der Account selbst Teil eines aktuellen Territorys ist, aber eine der Töchter. Dabei wird nur eine Ebene tief nach gültigen Territorys gesucht.
- Accounts werden nach ihrer aktuellen Quote und der aktuellen Pipeline jeweils absteigend sortiert.
- Die Detaildaten für CRM Projekte, Accounts und Territorys werden nun visuell einheitlich dargestellt.
- Wenn bei einem Projekt ein "On Hold" Datum gesetzt ist, dieses aber in der Vergangenheit liegt, wird dieses ignoriert und somit auch nicht mehr bei den Projektdaten angezeigt.
- Im Navigationsmenü werden nun zuerst Accounts, dann Personen und dann Projekte angezeigt. Es werden ausschließlich offene Projekte angezeigt.
- Projekte werden nach Wichtigkeit der Accounts und des Projektvolumens sortiert.
