### PR TITLE
Account Pipeline und Projektinformationen besser darstellen

### DIFF
--- a/api/ContextAccounts.tsx
+++ b/api/ContextAccounts.tsx
@@ -10,7 +10,7 @@ import {
 } from "@/helpers/accounts";
 import { calcPipeline } from "@/helpers/projects";
 import { SelectionSet, generateClient } from "aws-amplify/data";
-import { flow, map, sortBy } from "lodash/fp";
+import { flatMap, flow, map, sortBy, uniq } from "lodash/fp";
 import { FC, ReactNode, createContext, useContext } from "react";
 import useSWR from "swr";
 import { handleApiErrors } from "./globals";
@@ -100,6 +100,7 @@ export type AccountData = SelectionSet<
   Schema["Account"]["type"],
   typeof selectionSet
 >;
+type SubsidiaryData = AccountData["subsidiaries"][number];
 
 const mapAccount: (account: AccountData) => Account = ({
   id: accountId,
@@ -134,7 +135,12 @@ const mapAccount: (account: AccountData) => Account = ({
   territoryIds:
     territories.length > 0
       ? territories.map((t) => t.territory.id)
-      : subsidiaries.flatMap((s) => s.territories.map((t) => t.territory.id)),
+      : flow(
+          flatMap((s: SubsidiaryData) =>
+            s.territories.map((t) => t.territory.id)
+          ),
+          uniq
+        )(subsidiaries),
   payerAccounts: payerAccounts.map((p) => p.awsAccountNumber),
 });
 

--- a/api/ContextAccounts.tsx
+++ b/api/ContextAccounts.tsx
@@ -87,6 +87,7 @@ const selectionSet = [
   "subsidiaries.territories.territory.responsibilities.id",
   "subsidiaries.territories.territory.responsibilities.quota",
   "subsidiaries.territories.territory.responsibilities.startDate",
+  "projects.projects.done",
   "projects.projects.crmProjects.crmProject.id",
   "projects.projects.crmProjects.crmProject.closeDate",
   "projects.projects.crmProjects.crmProject.annualRecurringRevenue",

--- a/api/useTerritories.tsx
+++ b/api/useTerritories.tsx
@@ -284,16 +284,10 @@ const useTerritory = (id: string | undefined) => {
     startDate: Date,
     quota: number | undefined
   ) => {
-    console.log("updateTerritoryResponsibility", {
-      responsibilityId,
-      startDate,
-      quota,
-    });
     const { data, errors } = await client.models.TerritoryResponsibility.update(
       { id: responsibilityId, startDate: toISODateString(startDate), quota }
     );
     if (errors) handleApiErrors(errors, "Updating responsibility failed");
-    console.log("updateTerritoryResponsibility", { data, errors });
     return data?.id;
   };
 

--- a/components/accounts/AccountDetails.tsx
+++ b/components/accounts/AccountDetails.tsx
@@ -1,5 +1,7 @@
 import { Account, useAccountsContext } from "@/api/ContextAccounts";
+import { calcAccountAndSubsidariesPipeline } from "@/helpers/accounts";
 import { make2YearsRevenueText } from "@/helpers/projects";
+import { filter, flow, map, sum } from "lodash/fp";
 import { FC, useState } from "react";
 import CrmLink from "../crm/CrmLink";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
@@ -77,9 +79,19 @@ const AccountDetails: FC<AccountDetailsProps> = ({
           <DefaultAccordionItem
             value="subsidaries"
             triggerTitle="Subsidiaries"
-            triggerSubTitle={accounts
-              .filter((a) => a.controller?.id === account.id)
-              .map((a) => a.name)
+            triggerSubTitle={[
+              flow(
+                filter((a: Account) => a.controller?.id === account.id),
+                map(calcAccountAndSubsidariesPipeline(accounts)),
+                sum,
+                make2YearsRevenueText
+              )(accounts),
+              ...flow(
+                filter((a: Account) => a.controller?.id === account.id),
+                map((a) => a.name)
+              )(accounts),
+            ]
+              .filter((t) => t !== "")
               .join(", ")}
             isVisible={!!showSubsidaries}
             accordionSelectedValue={accordionValue}

--- a/components/accounts/ProjectList.tsx
+++ b/components/accounts/ProjectList.tsx
@@ -1,6 +1,11 @@
 import { useAccountsContext } from "@/api/ContextAccounts";
 import { useProjectsContext } from "@/api/ContextProjects";
-import { filterAndSortProjects, getRevenue2Years } from "@/helpers/projects";
+import {
+  calcRevenueTwoYears,
+  filterAndSortProjects,
+  getRevenue2Years,
+} from "@/helpers/projects";
+import { flow, map, sum } from "lodash/fp";
 import Link from "next/link";
 import { FC, useState } from "react";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
@@ -67,7 +72,7 @@ const ProjectList: FC<ProjectListProps> = ({
                     {getAccountById(id)?.name}
                   </Link>
                 ))}
-                {crmProjects.length > 0 && (
+                {flow(map(calcRevenueTwoYears), sum)(crmProjects) > 0 && (
                   <div className="truncate">
                     {getRevenue2Years(crmProjects)}
                   </div>

--- a/components/accounts/ProjectList.tsx
+++ b/components/accounts/ProjectList.tsx
@@ -63,6 +63,11 @@ const ProjectList: FC<ProjectListProps> = ({
             link={`/projects/${projectId}`}
             triggerSubTitle={
               <>
+                {flow(map(calcRevenueTwoYears), sum)(crmProjects) > 0 && (
+                  <div className="truncate">
+                    {getRevenue2Years(crmProjects)}
+                  </div>
+                )}
                 {accountIds.map((id: string) => (
                   <Link
                     key={id}
@@ -72,11 +77,6 @@ const ProjectList: FC<ProjectListProps> = ({
                     {getAccountById(id)?.name}
                   </Link>
                 ))}
-                {flow(map(calcRevenueTwoYears), sum)(crmProjects) > 0 && (
-                  <div className="truncate">
-                    {getRevenue2Years(crmProjects)}
-                  </div>
-                )}
               </>
             }
           >

--- a/components/accounts/account-record.tsx
+++ b/components/accounts/account-record.tsx
@@ -1,6 +1,9 @@
 import { Account, useAccountsContext } from "@/api/ContextAccounts";
 import useTerritories from "@/api/useTerritories";
+import { calcAccountAndSubsidariesPipeline } from "@/helpers/accounts";
 import { formatRevenue } from "@/helpers/functional";
+import { make2YearsRevenueText } from "@/helpers/projects";
+import { flow } from "lodash/fp";
 import { FC } from "react";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
 import AccountDetails from "./AccountDetails";
@@ -32,9 +35,12 @@ const AccountRecord: FC<AccountRecordProps> = ({
       value={account.id}
       triggerTitle={account.name}
       triggerSubTitle={[
-        ...(account.pipeline === 0
-          ? [""]
-          : [`Pipeline: ${formatRevenue(account.pipeline)}`]),
+        !accounts
+          ? ""
+          : flow(
+              calcAccountAndSubsidariesPipeline(accounts),
+              make2YearsRevenueText
+            )(account),
         ...(territories
           ?.filter((t) => account.territoryIds.includes(t.id))
           .map(

--- a/components/accounts/account-record.tsx
+++ b/components/accounts/account-record.tsx
@@ -32,6 +32,9 @@ const AccountRecord: FC<AccountRecordProps> = ({
       value={account.id}
       triggerTitle={account.name}
       triggerSubTitle={[
+        ...(account.pipeline === 0
+          ? [""]
+          : [`Pipeline: ${formatRevenue(account.pipeline)}`]),
         ...(territories
           ?.filter((t) => account.territoryIds.includes(t.id))
           .map(

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -3,8 +3,8 @@
 - Wenn ein Account mehrere Töchter hatte und diesen ein Territory zugeordnet war, dann wurden alle Territories angezeigt, auch wenn sie doppelt waren.
 - Pipeline wird in Accounts Subtitle mit anzeigt.
 - In der Accounts-Ansicht werden keine erledigten Projekte mehr angezeigt.
+- In Projekten wurde immer noch ein Revenue von $0 angezeigt, wenn ein CRM Projekt dran hing.
 
 In Arbeit:
 
-- In Projekten wurde immer noch ein Revenue von $0 angezeigt, wenn ein CRM Projekt dran hing.
 - Projektsortierung debuggen. Sieht immer noch nicht richtig aus

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,11 +1,7 @@
-# Sortiertung Projekte korrigieren (Version :VERSION)
+# Account Pipeline und Projektinformationen besser darstellen (Version :VERSION)
 
 - Wenn ein Account mehrere Töchter hatte und diesen ein Territory zugeordnet war, dann wurden alle Territories angezeigt, auch wenn sie doppelt waren.
 - Pipeline wird in Accounts Subtitle mit anzeigt.
 - In der Accounts-Ansicht werden keine erledigten Projekte mehr angezeigt.
 - In Projekten wurde immer noch ein Revenue von $0 angezeigt, wenn ein CRM Projekt dran hing.
 - Auch die Summe der Pipeline der Tochter-Unternehmen wird mit angezeigt.
-
-In Arbeit:
-
-- Projektsortierung debuggen. Sieht immer noch nicht richtig aus

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,3 +1,8 @@
 # Sortiertung Projekte korrigieren (Version :VERSION)
 
-Die Projekte wurden nicht sortiert. Jetzt werden sie nach "order" absteigend sortiert.
+- Wenn ein Account mehrere Töchter hatte und diesen ein Territory zugeordnet war, dann wurden alle Territories angezeigt, auch wenn sie doppelt waren.
+
+In Arbeit:
+
+- Pipeline in Accounts Subtitle mit anzeigen.
+- Projektsortierung debuggen. Sieht immer noch nicht richtig aus

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -4,6 +4,7 @@
 - Pipeline wird in Accounts Subtitle mit anzeigt.
 - In der Accounts-Ansicht werden keine erledigten Projekte mehr angezeigt.
 - In Projekten wurde immer noch ein Revenue von $0 angezeigt, wenn ein CRM Projekt dran hing.
+- Auch die Summe der Pipeline der Tochter-Unternehmen wird mit angezeigt.
 
 In Arbeit:
 

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -2,6 +2,7 @@
 
 - Wenn ein Account mehrere Töchter hatte und diesen ein Territory zugeordnet war, dann wurden alle Territories angezeigt, auch wenn sie doppelt waren.
 - Pipeline wird in Accounts Subtitle mit anzeigt.
+- In der Accounts-Ansicht werden keine erledigten Projekte mehr angezeigt.
 
 In Arbeit:
 

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,8 +1,9 @@
 # Sortiertung Projekte korrigieren (Version :VERSION)
 
 - Wenn ein Account mehrere Töchter hatte und diesen ein Territory zugeordnet war, dann wurden alle Territories angezeigt, auch wenn sie doppelt waren.
+- Pipeline wird in Accounts Subtitle mit anzeigt.
 
 In Arbeit:
 
-- Pipeline in Accounts Subtitle mit anzeigen.
+- In Projekten wurde immer noch ein Revenue von $0 angezeigt, wenn ein CRM Projekt dran hing.
 - Projektsortierung debuggen. Sieht immer noch nicht richtig aus

--- a/helpers/projects.ts
+++ b/helpers/projects.ts
@@ -8,9 +8,12 @@ import { calcOrder } from "./accounts";
 import { formatRevenue } from "./functional";
 
 interface CalcPipelineProps {
-  projects: {
-    crmProjects: CrmDataProps[];
-  };
+  projects: ProjectProps;
+}
+
+interface ProjectProps {
+  done?: boolean | null;
+  crmProjects: CrmDataProps[];
 }
 
 export interface ICalcRevenueTwoYears {
@@ -51,6 +54,7 @@ export const calcRevenueTwoYears = (crmProject: ICalcRevenueTwoYears) =>
 export const calcPipeline = (projects: CalcPipelineProps[]): number =>
   flow(
     map(get("projects")),
+    filter((p: ProjectProps) => !p.done),
     map(get("crmProjects")),
     flatMap(map(mapCrmData)),
     map(calcRevenueTwoYears),
@@ -80,7 +84,7 @@ export const filterByProjectStatus =
   (accountId: string | undefined, projectFilter: ProjectFilters | undefined) =>
   ({ accountIds, done, onHoldTill }: Project) =>
     accountId
-      ? accountIds.includes(accountId)
+      ? accountIds.includes(accountId) && !done
       : (projectFilter === "WIP" && !done && !onHoldTill) ||
         (projectFilter === "On Hold" && !done && onHoldTill) ||
         (projectFilter === "Done" && done);

--- a/helpers/projects.ts
+++ b/helpers/projects.ts
@@ -75,7 +75,7 @@ export const updateProjectOrder =
   });
 
 export const make2YearsRevenueText = (revenue: number) =>
-  `Revenue next 2Ys: ${formatRevenue(revenue)}`;
+  revenue === 0 ? "" : `Pipeline 2Ys: ${formatRevenue(revenue)}`;
 
 export const getRevenue2Years = (projects: ICalcRevenueTwoYears[]) =>
   make2YearsRevenueText(flow(map(calcRevenueTwoYears), sum)(projects));


### PR DESCRIPTION
- Wenn ein Account mehrere Töchter hatte und diesen ein Territory zugeordnet war, dann wurden alle Territories angezeigt, auch wenn sie doppelt waren.
- Pipeline wird in Accounts Subtitle mit anzeigt.
- In der Accounts-Ansicht werden keine erledigten Projekte mehr angezeigt.
- In Projekten wurde immer noch ein Revenue von $0 angezeigt, wenn ein CRM Projekt dran hing.
- Auch die Summe der Pipeline der Tochter-Unternehmen wird mit angezeigt.
