### PR TITLE
UI auf weitere Personen vorbereiten

### DIFF
--- a/components/CategoryTitle.tsx
+++ b/components/CategoryTitle.tsx
@@ -2,6 +2,7 @@ import { useRouter } from "next/router";
 import { ChangeEvent, FC, useEffect, useRef, useState } from "react";
 import { IoChevronBackOutline } from "react-icons/io5";
 import { Button } from "./ui/button";
+import { Skeleton } from "./ui/skeleton";
 
 export type CategoryTitleProps = {
   title?: string;
@@ -63,7 +64,9 @@ const CategoryTitle: FC<CategoryTitleProps> = (props) => {
             </Button>
           </div>
         )}
-        {title && (
+        {!title ? (
+          <Skeleton className="text-left md:text-center flex-1 h-6 md:h-8 p-0 mt-1 mb-2 md:mt-0" />
+        ) : (
           <div className="text-left md:text-center flex-1 text-2xl md:text-3xl font-bold leading-8 p-0 mt-0 tracking-tight">
             {props.saveTitle && isEditing ? (
               <textarea

--- a/components/accounts/AccountDetails.tsx
+++ b/components/accounts/AccountDetails.tsx
@@ -8,7 +8,7 @@ import {
 } from "@/helpers/projects";
 import { getEditorContent, TWithGetJsonFn } from "@/helpers/ui-notes-writer";
 import { filter, flow, get, map } from "lodash/fp";
-import { FC, useState } from "react";
+import { FC } from "react";
 import CrmLink from "../crm/CrmLink";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
 import { debouncedUpdateAccountDetails } from "../ui-elements/account-details/account-updates-helpers";
@@ -54,9 +54,6 @@ const AccountDetails: FC<AccountDetailsProps> = ({
   } = useAccountsContext();
   const { territories } = useTerritories();
   const { projects } = useProjectsContext();
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
 
   const handleUpdateIntroduction = (editor: TWithGetJsonFn) => {
     if (!account) return;
@@ -84,14 +81,7 @@ const AccountDetails: FC<AccountDetailsProps> = ({
         )}
       </div>
 
-      <Accordion
-        type="single"
-        collapsible
-        value={accordionValue}
-        onValueChange={(val) =>
-          setAccordionValue(val === accordionValue ? undefined : val)
-        }
-      >
+      <Accordion type="single" collapsible>
         {accounts && (
           <DefaultAccordionItem
             value="subsidaries"
@@ -107,7 +97,6 @@ const AccountDetails: FC<AccountDetailsProps> = ({
               )(accounts),
             ]}
             isVisible={!!showSubsidaries}
-            accordionSelectedValue={accordionValue}
           >
             <AccountsList
               accounts={accounts}
@@ -123,7 +112,6 @@ const AccountDetails: FC<AccountDetailsProps> = ({
           value="introduction"
           triggerTitle="Introduction"
           isVisible={!!showIntroduction}
-          accordionSelectedValue={accordionValue}
         >
           <NotesWriter
             notes={account.introduction}
@@ -140,28 +128,19 @@ const AccountDetails: FC<AccountDetailsProps> = ({
             make2YearsRevenueText
           )(projects)}
           isVisible={!!showProjects}
-          accordionSelectedValue={accordionValue}
         >
           <ProjectList accountId={account.id} />
         </DefaultAccordionItem>
 
-        <AccountPeople
-          accountId={account.id}
-          isVisible={!!showContacts}
-          accordionSelectedValue={accordionValue}
-        />
+        <AccountPeople accountId={account.id} isVisible={!!showContacts} />
 
-        <AccountNotes
-          accountId={account.id}
-          accordionSelectedValue={accordionValue}
-        />
+        <AccountNotes accountId={account.id} />
 
         <DefaultAccordionItem
           value="aws-accounts"
           triggerTitle="AWS Payer Accounts"
           triggerSubTitle={account.payerAccounts}
           isVisible={!!showAwsAccounts && account.payerAccounts.length > 0}
-          accordionSelectedValue={accordionValue}
         >
           <ListPayerAccounts
             payerAccounts={account.payerAccounts}
@@ -183,7 +162,6 @@ const AccountDetails: FC<AccountDetailsProps> = ({
             )(territories),
           ]}
           isVisible={!!showTerritories && account.territoryIds.length > 0}
-          accordionSelectedValue={accordionValue}
         >
           <ListTerritories territoryIds={account.territoryIds} />
         </DefaultAccordionItem>

--- a/components/accounts/AccountNotes.tsx
+++ b/components/accounts/AccountNotes.tsx
@@ -5,21 +5,13 @@ import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem"
 
 type AccountNotesProps = {
   accountId: string;
-  accordionSelectedValue?: string;
 };
 
-const AccountNotes: FC<AccountNotesProps> = ({
-  accountId,
-  accordionSelectedValue,
-}) => {
+const AccountNotes: FC<AccountNotesProps> = ({ accountId }) => {
   const { activities } = useAccountActivities(accountId);
 
   return (
-    <DefaultAccordionItem
-      value="notes"
-      triggerTitle="Notes"
-      accordionSelectedValue={accordionSelectedValue}
-    >
+    <DefaultAccordionItem value="notes" triggerTitle="Notes">
       {activities?.map((a) => (
         <ActivityComponent
           key={a.id}

--- a/components/accounts/AccountPeople.tsx
+++ b/components/accounts/AccountPeople.tsx
@@ -1,17 +1,15 @@
-import { FC } from "react";
-import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
 import useAccountPeople from "@/api/useAccountPeople";
+import { FC } from "react";
 import PeopleList from "../people/PeopleList";
+import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
 
 type AccountPeopleProps = {
   accountId: string;
   isVisible?: boolean;
-  accordionSelectedValue?: string;
 };
 
 const AccountPeople: FC<AccountPeopleProps> = ({
   accountId,
-  accordionSelectedValue,
   isVisible = true,
 }) => {
   const { people } = useAccountPeople(accountId);
@@ -22,7 +20,6 @@ const AccountPeople: FC<AccountPeopleProps> = ({
       triggerTitle="Contacts"
       triggerSubTitle={people?.map((p) => p.name)}
       isVisible={isVisible}
-      accordionSelectedValue={accordionSelectedValue}
     >
       <PeopleList personIds={people?.map((p) => p.id)} />
     </DefaultAccordionItem>

--- a/components/accounts/AccountsList.tsx
+++ b/components/accounts/AccountsList.tsx
@@ -1,5 +1,5 @@
 import { Account } from "@/api/ContextAccounts";
-import { FC, useState } from "react";
+import { FC } from "react";
 import { Accordion } from "../ui/accordion";
 import AccountRecord from "./account-record";
 
@@ -19,12 +19,8 @@ const AccountsList: FC<AccountsListProps> = ({
   showIntroduction,
   showProjects,
   showSubsidaries = true,
-}) => {
-  const [selectedAccount, setSelectedAccount] = useState<string | undefined>(
-    undefined
-  );
-
-  return !accounts ? (
+}) =>
+  !accounts ? (
     "Loading accounts…"
   ) : accounts.filter(
       ({ controller }) =>
@@ -36,14 +32,7 @@ const AccountsList: FC<AccountsListProps> = ({
       "No subsidiaries"
     )
   ) : (
-    <Accordion
-      type="single"
-      collapsible
-      value={selectedAccount}
-      onValueChange={(val) =>
-        setSelectedAccount(val === selectedAccount ? undefined : val)
-      }
-    >
+    <Accordion type="single" collapsible>
       {accounts
         .filter(
           ({ controller }) =>
@@ -53,7 +42,6 @@ const AccountsList: FC<AccountsListProps> = ({
           <AccountRecord
             key={account.id}
             account={account}
-            selectedAccordionItem={selectedAccount}
             showContacts={showContacts}
             showIntroduction={showIntroduction}
             showProjects={showProjects}
@@ -62,6 +50,5 @@ const AccountsList: FC<AccountsListProps> = ({
         ))}
     </Accordion>
   );
-};
 
 export default AccountsList;

--- a/components/accounts/ProjectList.tsx
+++ b/components/accounts/ProjectList.tsx
@@ -1,7 +1,7 @@
 import { useAccountsContext } from "@/api/ContextAccounts";
 import { useProjectsContext } from "@/api/ContextProjects";
 import { filterAndSortProjects } from "@/helpers/projects";
-import { FC, useState } from "react";
+import { FC } from "react";
 import ProjectAccordionItem from "../projects/ProjectAccordionItem";
 import { Accordion } from "../ui/accordion";
 
@@ -28,9 +28,6 @@ const ProjectList: FC<ProjectListProps> = ({
 }) => {
   const { projects } = useProjectsContext();
   const { accounts } = useAccountsContext();
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
 
   return !projects ? (
     "Loading…"
@@ -38,21 +35,10 @@ const ProjectList: FC<ProjectListProps> = ({
       .length === 0 ? (
     "No projects"
   ) : (
-    <Accordion
-      type="single"
-      collapsible
-      value={accordionValue}
-      onValueChange={(val) =>
-        setAccordionValue(val === accordionValue ? undefined : val)
-      }
-    >
+    <Accordion type="single" collapsible>
       {filterAndSortProjects(projects, accountId, projectFilter, accounts).map(
         (project) => (
-          <ProjectAccordionItem
-            key={project.id}
-            project={project}
-            accordionSelectedValue={accordionValue}
-          />
+          <ProjectAccordionItem key={project.id} project={project} />
         )
       )}
     </Accordion>

--- a/components/accounts/account-record.tsx
+++ b/components/accounts/account-record.tsx
@@ -18,7 +18,6 @@ type AccountRecordProps = {
 
 const AccountRecord: FC<AccountRecordProps> = ({
   account,
-  selectedAccordionItem,
   showContacts,
   showIntroduction,
   showProjects,
@@ -46,7 +45,6 @@ const AccountRecord: FC<AccountRecordProps> = ({
         )(accounts),
       ]}
       link={`/accounts/${account.id}`}
-      accordionSelectedValue={selectedAccordionItem}
     >
       <AccountDetails
         account={account}

--- a/components/activities/activity-meeting-list.tsx
+++ b/components/activities/activity-meeting-list.tsx
@@ -3,26 +3,21 @@ import usePeople from "@/api/usePeople";
 import { Person } from "@/api/usePerson";
 import { format } from "date-fns";
 import { filter, flow, map } from "lodash/fp";
-import { FC, useState } from "react";
+import { FC } from "react";
 import MeetingAccordionItem from "../meetings/MeetingAccordionItem";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
 import { Accordion } from "../ui/accordion";
 
 type ActivityMeetingListProps = {
   meeting?: Meeting;
-  accordionSelectedValue?: string;
   showMeeting?: boolean;
 };
 
 const ActivityMeetingList: FC<ActivityMeetingListProps> = ({
   meeting,
-  accordionSelectedValue,
   showMeeting,
 }) => {
   const { people } = usePeople();
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
 
   return (
     meeting && (
@@ -40,21 +35,10 @@ const ActivityMeetingList: FC<ActivityMeetingListProps> = ({
           )(people),
         ]}
         className="tracking-tight"
-        accordionSelectedValue={accordionSelectedValue}
         isVisible={showMeeting && !!meeting}
       >
-        <Accordion
-          type="single"
-          collapsible
-          value={accordionValue}
-          onValueChange={(val) =>
-            setAccordionValue(val === accordionValue ? undefined : val)
-          }
-        >
-          <MeetingAccordionItem
-            meeting={meeting}
-            accordionSelectedValue={accordionValue}
-          />
+        <Accordion type="single" collapsible>
+          <MeetingAccordionItem meeting={meeting} />
         </Accordion>
       </DefaultAccordionItem>
     )

--- a/components/activities/activity-notes.tsx
+++ b/components/activities/activity-notes.tsx
@@ -14,17 +14,12 @@ import ActivityMetaData from "./activity-meta-data";
 
 type ActivityNotesProps = {
   activity?: Activity;
-  accordionSelectedValue?: string;
   updateNotes: (
     serializedOutput: SerializerOutput
   ) => Promise<string | undefined>;
 };
 
-const ActivityNotes: FC<ActivityNotesProps> = ({
-  activity,
-  accordionSelectedValue,
-  updateNotes,
-}) => {
+const ActivityNotes: FC<ActivityNotesProps> = ({ activity, updateNotes }) => {
   const { mutateOpenTasks } = useOpenTasksContext();
 
   const handleNotesUpdate = (editor: TWithGetJsonFn) => {
@@ -44,7 +39,6 @@ const ActivityNotes: FC<ActivityNotesProps> = ({
       triggerTitle="Notes"
       triggerSubTitle={getTextFromEditorJsonContent(activity.notes)}
       className="tracking-tight"
-      accordionSelectedValue={accordionSelectedValue}
     >
       <NotesWriter
         notes={activity.notes}

--- a/components/activities/activity-project-list.tsx
+++ b/components/activities/activity-project-list.tsx
@@ -1,7 +1,7 @@
 import { useAccountsContext } from "@/api/ContextAccounts";
 import { Project, useProjectsContext } from "@/api/ContextProjects";
 import { filter, flow, map } from "lodash/fp";
-import { FC, useState } from "react";
+import { FC } from "react";
 import ProjectAccordionItem from "../projects/ProjectAccordionItem";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
 import ProjectSelector from "../ui-elements/selectors/project-selector";
@@ -12,21 +12,16 @@ type ActivityProjectListProps = {
   addProjectToActivity?: (
     projectId: string | null
   ) => Promise<string | undefined>;
-  accordionSelectedValue?: string;
   showProjects?: boolean;
 };
 
 const ActivityProjectList: FC<ActivityProjectListProps> = ({
   projectIds,
   addProjectToActivity,
-  accordionSelectedValue,
   showProjects,
 }) => {
   const { projects } = useProjectsContext();
   const { getAccountNamesByIds } = useAccountsContext();
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
 
   return !projectIds || !projects ? (
     "Loading…"
@@ -44,7 +39,6 @@ const ActivityProjectList: FC<ActivityProjectListProps> = ({
         )
       )(projects)}
       className="tracking-tight"
-      accordionSelectedValue={accordionSelectedValue}
       isVisible={showProjects}
     >
       {addProjectToActivity && (
@@ -55,21 +49,13 @@ const ActivityProjectList: FC<ActivityProjectListProps> = ({
         />
       )}
 
-      <Accordion
-        type="single"
-        collapsible
-        value={accordionValue}
-        onValueChange={(val) =>
-          setAccordionValue(val === accordionValue ? undefined : val)
-        }
-      >
+      <Accordion type="single" collapsible>
         {flow(
           filter((p: Project) => projectIds.includes(p.id)),
           map((project) => (
             <ProjectAccordionItem
               key={project.id}
               project={project}
-              accordionSelectedValue={accordionValue}
               showNotes={false}
             />
           ))

--- a/components/activities/activity.tsx
+++ b/components/activities/activity.tsx
@@ -29,7 +29,6 @@ type ActivityComponentProps = {
   autoFocus?: boolean;
   allowAddingProjects?: boolean;
   notesNotInAccordion?: boolean;
-  accordionSelectedValue?: string;
 };
 
 const ActivityComponent: FC<ActivityComponentProps> = ({
@@ -39,7 +38,6 @@ const ActivityComponent: FC<ActivityComponentProps> = ({
   showProjects,
   allowAddingProjects,
   notesNotInAccordion,
-  accordionSelectedValue,
 }) => {
   const { activity, updateNotes, updateDate, addProjectToActivity } =
     useActivity(activityId);
@@ -47,9 +45,6 @@ const ActivityComponent: FC<ActivityComponentProps> = ({
   const { meeting, deleteMeetingActivity } = useMeeting(activity?.meetingId);
   const [dateSaved, setDateSaved] = useState(true);
   const [date, setDate] = useState(activity?.finishedOn || new Date());
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
   const { toast } = useToast();
 
   useEffect(() => {
@@ -114,41 +109,23 @@ const ActivityComponent: FC<ActivityComponentProps> = ({
         </div>
       )}
 
-      <Accordion
-        type="single"
-        collapsible
-        className="w-full"
-        value={accordionValue}
-        onValueChange={(val) =>
-          setAccordionValue(val === accordionValue ? undefined : val)
-        }
-      >
+      <Accordion type="single" collapsible>
         <ActivityProjectList
           projectIds={activity?.projectIds}
           addProjectToActivity={
             !allowAddingProjects ? undefined : addProjectToActivity
           }
-          accordionSelectedValue={accordionValue}
           showProjects={showProjects}
         />
 
-        <ActivityMeetingList
-          meeting={meeting}
-          accordionSelectedValue={accordionValue}
-          showMeeting={showMeeting}
-        />
+        <ActivityMeetingList meeting={meeting} showMeeting={showMeeting} />
 
-        <ActivityNotes
-          activity={activity}
-          accordionSelectedValue={accordionValue}
-          updateNotes={updateNotes}
-        />
+        <ActivityNotes activity={activity} updateNotes={updateNotes} />
       </Accordion>
     </div>
   ) : (
     <DefaultAccordionItem
       value={activityId}
-      accordionSelectedValue={accordionSelectedValue}
       triggerTitle="Meeting notes"
       triggerSubTitle={`Projects: ${getProjectNamesByIds(
         activity?.projectIds

--- a/components/combo-box/combo-box.tsx
+++ b/components/combo-box/combo-box.tsx
@@ -27,6 +27,7 @@ type ComboBoxProps = {
   onChange?: (selectedValue: string | null) => void;
   onCreate?: (newLabel: string) => void;
   createItemLabel?: string;
+  disabled?: boolean;
 };
 
 const ComboBox: FC<ComboBoxProps> = ({
@@ -34,6 +35,7 @@ const ComboBox: FC<ComboBoxProps> = ({
   currentValue,
   onChange,
   onCreate,
+  disabled,
   placeholder = "Search for entry…",
   noSearchResultMsg = "No entry found.",
   loadingResultsMsg = "Loading results…",
@@ -52,6 +54,7 @@ const ComboBox: FC<ComboBoxProps> = ({
             "px-2 md:px-4 w-full justify-between",
             !currentValue && "text-muted-foreground"
           )}
+          disabled={disabled}
         >
           {options?.find((o) => o.value === currentValue)?.label || placeholder}
           <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />

--- a/components/header/ProfilePicture.tsx
+++ b/components/header/ProfilePicture.tsx
@@ -1,5 +1,9 @@
+import useCurrentUser from "@/api/useUser";
 import { signOut } from "aws-amplify/auth";
+import { getUrl } from "aws-amplify/storage";
 import { LogOut, UserCircle2 } from "lucide-react";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
 import {
   DropdownMenu,
@@ -10,17 +14,12 @@ import {
   DropdownMenuTrigger,
 } from "../ui/dropdown-menu";
 import Version from "../version/version";
-import useCurrentUser from "@/api/useUser";
-import { useRouter } from "next/router";
-import { useEffect, useState } from "react";
-import { getUrl } from "aws-amplify/storage";
 
 const ProfilePicture = () => {
   const { user, createProfile } = useCurrentUser();
   const [open, setOpen] = useState(false);
   const [isCreatingProfile, setIsCreatingProfile] = useState(false);
   const [imageUrl, setImgUrl] = useState<string | undefined>(undefined);
-  const router = useRouter();
 
   const setCurrentImgUrl = async (
     key: string | undefined,
@@ -65,9 +64,11 @@ const ProfilePicture = () => {
           </p>
         </DropdownMenuLabel>
         <DropdownMenuSeparator />
-        <DropdownMenuItem onClick={() => router.replace("/profile")}>
-          <UserCircle2 className="mr-2 h-4 w-4" />
-          <span>Profile</span>
+        <DropdownMenuItem asChild>
+          <Link href="/profile">
+            <UserCircle2 className="mr-2 h-4 w-4" />
+            <span>Profile</span>
+          </Link>
         </DropdownMenuItem>
         <DropdownMenuItem onClick={() => signOut()}>
           <LogOut className="mr-2 h-4 w-4" />

--- a/components/meetings/MeetingAccordionItem.tsx
+++ b/components/meetings/MeetingAccordionItem.tsx
@@ -11,13 +11,9 @@ import MeetingRecord from "./meeting";
 
 type MeetingAccordionItemProps = {
   meeting: Meeting;
-  accordionSelectedValue?: string;
 };
 
-const MeetingAccordionItem: FC<MeetingAccordionItemProps> = ({
-  meeting,
-  accordionSelectedValue,
-}) => {
+const MeetingAccordionItem: FC<MeetingAccordionItemProps> = ({ meeting }) => {
   const { getNamesByIds } = usePeople();
   const { getProjectNamesByIds } = useProjectsContext();
 
@@ -26,7 +22,6 @@ const MeetingAccordionItem: FC<MeetingAccordionItemProps> = ({
       value={meeting.id}
       triggerTitle={`${meeting.topic} (${format(meeting.meetingOn, "Pp")})`}
       className="tracking-tight"
-      accordionSelectedValue={accordionSelectedValue}
       link={`/meetings/${meeting.id}`}
       hasOpenTasks={meeting.activities.some((a) => a.hasOpenTasks)}
       hasClosedTasks={meeting.activities.some((a) => a.closedTasks?.length)}

--- a/components/meetings/meeting-activity-list.tsx
+++ b/components/meetings/meeting-activity-list.tsx
@@ -4,22 +4,22 @@ import ActivityComponent from "../activities/activity";
 
 type MeetingActivityListProps = {
   meeting: Meeting;
-  accordionSelectedValue?: string;
 };
 
-const MeetingActivityList: FC<MeetingActivityListProps> = ({
-  accordionSelectedValue,
-  meeting,
-}) =>
-  meeting.activities.length > 0 &&
-  meeting.activities.map((a) => (
-    <ActivityComponent
-      key={a.id}
-      activityId={a.id}
-      showMeeting={false}
-      notesNotInAccordion
-      accordionSelectedValue={accordionSelectedValue}
-    />
-  ));
+const MeetingActivityList: FC<MeetingActivityListProps> = ({ meeting }) =>
+  meeting.activities.length === 0 ? (
+    <div className="mx-2 md:mx-4 mt-8 font-semibold text-sm text-muted-foreground md:text-center">
+      Select a project to start taking notes!
+    </div>
+  ) : (
+    meeting.activities.map((a) => (
+      <ActivityComponent
+        key={a.id}
+        activityId={a.id}
+        showMeeting={false}
+        notesNotInAccordion
+      />
+    ))
+  );
 
 export default MeetingActivityList;

--- a/components/meetings/meeting-date-list.tsx
+++ b/components/meetings/meeting-date-list.tsx
@@ -1,6 +1,6 @@
 import { Meeting } from "@/api/useMeetings";
 import { filter, flow, map } from "lodash/fp";
-import { FC, useState } from "react";
+import { FC } from "react";
 import { Accordion } from "../ui/accordion";
 import MeetingAccordionItem from "./MeetingAccordionItem";
 
@@ -12,42 +12,25 @@ type MeetingDateListProps = {
 const MeetingDateList: FC<MeetingDateListProps> = ({
   meetings,
   meetingDate,
-}) => {
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
+}) => (
+  <div>
+    <h1 className="text-center text-lg md:text-xl font-bold bg-bgTransparent sticky top-[10rem] md:top-[11rem] z-30 tracking-tight pb-1">
+      {meetingDate.toLocaleDateString()}
+    </h1>
 
-  return (
-    <div>
-      <h1 className="text-center text-lg md:text-xl font-bold bg-bgTransparent sticky top-[10rem] md:top-[11rem] z-30 tracking-tight pb-1">
-        {meetingDate.toLocaleDateString()}
-      </h1>
-
-      <Accordion
-        type="single"
-        collapsible
-        value={accordionValue}
-        onValueChange={(val) =>
-          setAccordionValue(val === accordionValue ? undefined : val)
-        }
-      >
-        {flow(
-          filter(
-            (m: Meeting) =>
-              m.meetingOn.toISOString().split("T")[0] ===
-              meetingDate.toISOString().split("T")[0]
-          ),
-          map((meeting) => (
-            <MeetingAccordionItem
-              key={meeting.id}
-              accordionSelectedValue={accordionValue}
-              meeting={meeting}
-            />
-          ))
-        )(meetings)}
-      </Accordion>
-    </div>
-  );
-};
+    <Accordion type="single" collapsible>
+      {flow(
+        filter(
+          (m: Meeting) =>
+            m.meetingOn.toISOString().split("T")[0] ===
+            meetingDate.toISOString().split("T")[0]
+        ),
+        map((meeting) => (
+          <MeetingAccordionItem key={meeting.id} meeting={meeting} />
+        ))
+      )(meetings)}
+    </Accordion>
+  </div>
+);
 
 export default MeetingDateList;

--- a/components/meetings/meeting-next-actions.tsx
+++ b/components/meetings/meeting-next-actions.tsx
@@ -1,57 +1,42 @@
 import { OpenTask, useOpenTasksContext } from "@/api/ContextOpenTasks";
 import { Meeting } from "@/api/useMeetings";
 import { getTextFromEditorJsonContent } from "@/helpers/ui-notes-writer";
-import { FC, useState } from "react";
+import { FC } from "react";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
 import NextAction from "../ui-elements/project-details/next-action";
 import { Accordion } from "../ui/accordion";
 
 type MeetingNextActionsProps = {
   meeting: Meeting;
-  accordionSelectedValue?: string;
 };
 
-const MeetingNextActions: FC<MeetingNextActionsProps> = ({
-  meeting,
-  accordionSelectedValue,
-}) => {
+const MeetingNextActions: FC<MeetingNextActionsProps> = ({ meeting }) => {
   const { openTasks } = useOpenTasksContext();
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
 
   const getOpenTasksFromMeetingActivities = () =>
-    openTasks?.filter((task) => task.meetingId === meeting.id);
+    openTasks?.filter((task) => task.meetingId === meeting.id) ?? [];
 
   const getTasksText = ({ openTask }: OpenTask) =>
     getTextFromEditorJsonContent(openTask).trim();
 
   return (
-    <DefaultAccordionItem
-      value="next-actions"
-      triggerTitle="Agreed Next Actions"
-      triggerSubTitle={getOpenTasksFromMeetingActivities()?.map(getTasksText)}
-      accordionSelectedValue={accordionSelectedValue}
-    >
-      <Accordion
-        type="single"
-        collapsible
-        value={accordionValue}
-        onValueChange={(val) =>
-          setAccordionValue(val === accordionValue ? undefined : val)
-        }
+    getOpenTasksFromMeetingActivities().length > 0 && (
+      <DefaultAccordionItem
+        value="next-actions"
+        triggerTitle="Agreed Next Actions"
+        triggerSubTitle={getOpenTasksFromMeetingActivities()?.map(getTasksText)}
       >
-        {!getOpenTasksFromMeetingActivities()?.length && "No open tasks"}
-        {getOpenTasksFromMeetingActivities()?.map((openTask) => (
-          <NextAction
-            key={`${openTask.activityId}-${openTask.index}`}
-            openTask={openTask}
-            accordionSelectedValue={accordionValue}
-            showMeeting
-          />
-        ))}
-      </Accordion>
-    </DefaultAccordionItem>
+        <Accordion type="single" collapsible>
+          {getOpenTasksFromMeetingActivities().map((openTask) => (
+            <NextAction
+              key={`${openTask.activityId}-${openTask.index}`}
+              openTask={openTask}
+              showMeeting
+            />
+          ))}
+        </Accordion>
+      </DefaultAccordionItem>
+    )
   );
 };
 

--- a/components/meetings/meeting-participants.tsx
+++ b/components/meetings/meeting-participants.tsx
@@ -6,12 +6,10 @@ import PeopleSelector from "../ui-elements/selectors/people-selector";
 
 type MeetingParticipantsProps = {
   participantIds: string[];
-  accordionSelectedValue?: string;
   addParticipant?: (personId: string | null) => void;
 };
 
 const MeetingParticipants: FC<MeetingParticipantsProps> = ({
-  accordionSelectedValue,
   participantIds,
   addParticipant,
 }) => {
@@ -23,7 +21,6 @@ const MeetingParticipants: FC<MeetingParticipantsProps> = ({
         value="participants"
         triggerTitle="Participants"
         triggerSubTitle={getNamesByIds(participantIds)}
-        accordionSelectedValue={accordionSelectedValue}
       >
         {addParticipant && (
           <PeopleSelector

--- a/components/navigation-menu/SearchableDataGroup.tsx
+++ b/components/navigation-menu/SearchableDataGroup.tsx
@@ -1,4 +1,3 @@
-import { useNavMenuContext } from "@/contexts/NavMenuContext";
 import { useCommandState } from "cmdk";
 import { useRouter } from "next/router";
 import { FC } from "react";
@@ -6,6 +5,7 @@ import { CommandGroup, CommandItem } from "../ui/command";
 
 type SearchableDataGroupProps = {
   heading: string;
+  metaPressed?: boolean;
   items?: {
     id: string;
     value: string;
@@ -16,10 +16,16 @@ type SearchableDataGroupProps = {
 const SearchableDataGroup: FC<SearchableDataGroupProps> = ({
   heading,
   items,
+  metaPressed,
 }) => {
-  const router = useRouter();
-  const { toggleMenu } = useNavMenuContext();
   const search = useCommandState((state) => state.search);
+  const router = useRouter();
+
+  const routeToUrl = (url?: string) => () => {
+    if (!url) return;
+    if (metaPressed) window.open(url, "_blank");
+    else router.push(url);
+  };
 
   return (
     search &&
@@ -27,13 +33,7 @@ const SearchableDataGroup: FC<SearchableDataGroupProps> = ({
     items && (
       <CommandGroup heading={heading}>
         {items.map(({ id, value, link }) => (
-          <CommandItem
-            key={id}
-            onSelect={() => {
-              router.replace(link);
-              toggleMenu();
-            }}
-          >
+          <CommandItem key={id} onSelect={routeToUrl(link)}>
             {value}
           </CommandItem>
         ))}

--- a/components/people/PeopleList.tsx
+++ b/components/people/PeopleList.tsx
@@ -1,10 +1,10 @@
-import { FC, useState } from "react";
-import { Accordion } from "../ui/accordion";
-import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
 import usePeople from "@/api/usePeople";
-import PersonDetails from "./PersonDetails";
-import { filter, find, flatMap, flow, get } from "lodash/fp";
 import { Person, PersonAccount } from "@/api/usePerson";
+import { filter, find, flatMap, flow, get } from "lodash/fp";
+import { FC } from "react";
+import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
+import { Accordion } from "../ui/accordion";
+import PersonDetails from "./PersonDetails";
 
 type PeopleListProps = {
   personIds?: string[];
@@ -12,20 +12,10 @@ type PeopleListProps = {
 };
 
 const PeopleList: FC<PeopleListProps> = ({ personIds, showNotes }) => {
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
   const { people } = usePeople();
 
   return (
-    <Accordion
-      type="single"
-      collapsible
-      value={accordionValue}
-      onValueChange={(val) =>
-        setAccordionValue(val === accordionValue ? undefined : val)
-      }
-    >
+    <Accordion type="single" collapsible>
       {personIds?.map((personId) => (
         <DefaultAccordionItem
           key={personId}

--- a/components/people/PersonAccounts.tsx
+++ b/components/people/PersonAccounts.tsx
@@ -4,17 +4,16 @@ import {
   PersonAccountCreateProps,
   PersonAccountUpdateProps,
 } from "@/api/usePerson";
+import { format } from "date-fns";
+import { filter, flatMap, flow } from "lodash/fp";
+import { Trash2 } from "lucide-react";
+import Link from "next/link";
 import { FC } from "react";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
 import PersonAccountForm from "./PersonAccountForm";
-import { format } from "date-fns";
-import { Trash2 } from "lucide-react";
-import { filter, flatMap, flow } from "lodash/fp";
-import Link from "next/link";
 
 type PersonAccountsProps = {
   person: Person;
-  accordionSelectedValue?: string;
   onCreate: (data: PersonAccountCreateProps) => Promise<string | undefined>;
   onChange: (data: PersonAccountUpdateProps) => Promise<string | undefined>;
   onDelete: (personAccountId: string) => Promise<string | undefined>;
@@ -22,7 +21,6 @@ type PersonAccountsProps = {
 
 const PersonAccounts: FC<PersonAccountsProps> = ({
   person,
-  accordionSelectedValue,
   onCreate,
   onChange,
   onDelete,
@@ -38,7 +36,6 @@ const PersonAccounts: FC<PersonAccountsProps> = ({
         pa.startDate && `since ${format(pa.startDate, "PP")}`,
       ])
     )(person.accounts)}
-    accordionSelectedValue={accordionSelectedValue}
   >
     <PersonAccountForm personName={person.name} onCreate={onCreate} />
 

--- a/components/people/PersonContactDetails.tsx
+++ b/components/people/PersonContactDetails.tsx
@@ -6,12 +6,11 @@ import {
 } from "@/api/usePerson";
 import { FC } from "react";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
-import PersonContactDetailsForm from "./PersonContactDetailsForm";
 import PersonContactDetail from "./PersonContactDetail";
+import PersonContactDetailsForm from "./PersonContactDetailsForm";
 
 type PersonContactDetailsProps = {
   person: Person;
-  accordionSelectedValue?: string;
   onCreate: (data: PersonContactDetailsCreateProps) => void;
   onChange: (data: PersonContactDetailsUpdateProps) => void;
   onDelete: (personDetailId: string) => void;
@@ -19,7 +18,6 @@ type PersonContactDetailsProps = {
 
 const PersonContactDetails: FC<PersonContactDetailsProps> = ({
   person,
-  accordionSelectedValue,
   onCreate,
   onChange,
   onDelete,
@@ -33,7 +31,6 @@ const PersonContactDetails: FC<PersonContactDetailsProps> = ({
           personDetailsLabels.find((l) => l.fieldLabel === d.label)?.formLabel
         }: ${d.detail}`
     )}
-    accordionSelectedValue={accordionSelectedValue}
   >
     <PersonContactDetailsForm personName={person.name} onCreate={onCreate} />
 

--- a/components/people/PersonDates.tsx
+++ b/components/people/PersonDates.tsx
@@ -30,18 +30,15 @@ const PersonDateHelper: FC<PersonDateHelperProps> = ({ id, label, value }) => (
 
 type PersonDatesProps = {
   person: Person;
-  accordionSelectedValue?: string;
 };
 
 const PersonDates: FC<PersonDatesProps> = ({
   person: { dateOfBirth, dateOfDeath },
-  accordionSelectedValue,
 }) => {
   return (
     <DefaultAccordionItem
       value="person-dates"
       triggerTitle="Person's dates"
-      accordionSelectedValue={accordionSelectedValue}
       isVisible
       triggerSubTitle={[
         dateOfBirth && `Date of birth: ${format(dateOfBirth, "PPP")}`,

--- a/components/people/PersonDetails.tsx
+++ b/components/people/PersonDetails.tsx
@@ -1,12 +1,12 @@
 import usePerson from "@/api/usePerson";
-import { FC, useState } from "react";
+import { FC } from "react";
 import { Accordion } from "../ui/accordion";
-import PersonDates from "./PersonDates";
-import PersonNotes from "./PersonNotes";
-import PersonUpdateForm from "./PersonUpdateForm";
 import PersonAccounts from "./PersonAccounts";
 import PersonContactDetails from "./PersonContactDetails";
+import PersonDates from "./PersonDates";
 import PersonLearnings from "./PersonLearnings";
+import PersonNotes from "./PersonNotes";
+import PersonUpdateForm from "./PersonUpdateForm";
 
 type PersonDetailsProps = {
   personId: string;
@@ -32,9 +32,6 @@ const PersonDetails: FC<PersonDetailsProps> = ({
     updateContactDetail,
     deleteContactDetail,
   } = usePerson(personId);
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
 
   return (
     person && (
@@ -47,17 +44,9 @@ const PersonDetails: FC<PersonDetailsProps> = ({
           />
         </div>
 
-        <Accordion
-          type="single"
-          collapsible
-          value={accordionValue}
-          onValueChange={(val) =>
-            setAccordionValue(val === accordionValue ? undefined : val)
-          }
-        >
+        <Accordion type="single" collapsible>
           <PersonAccounts
             person={person}
-            accordionSelectedValue={accordionValue}
             onCreate={createPersonAccount}
             onDelete={deletePersonAccount}
             onChange={updatePersonAccount}
@@ -65,27 +54,16 @@ const PersonDetails: FC<PersonDetailsProps> = ({
 
           <PersonContactDetails
             person={person}
-            accordionSelectedValue={accordionValue}
             onCreate={createContactDetail}
             onChange={updateContactDetail}
             onDelete={deleteContactDetail}
           />
 
-          <PersonDates
-            person={person}
-            accordionSelectedValue={accordionValue}
-          />
+          <PersonDates person={person} />
 
-          <PersonLearnings
-            accordionSelectedValue={accordionValue}
-            personId={person.id}
-          />
+          <PersonLearnings personId={person.id} />
 
-          <PersonNotes
-            personId={person.id}
-            accordionSelectedValue={accordionValue}
-            showNotes={showNotes}
-          />
+          <PersonNotes personId={person.id} showNotes={showNotes} />
         </Accordion>
       </>
     )

--- a/components/people/PersonLearnings.tsx
+++ b/components/people/PersonLearnings.tsx
@@ -31,13 +31,9 @@ const debouncedUpdateLearnings = debounce(
 
 type PersonLearningsProps = {
   personId?: string;
-  accordionSelectedValue?: string;
 };
 
-const PersonLearnings: FC<PersonLearningsProps> = ({
-  personId,
-  accordionSelectedValue,
-}) => {
+const PersonLearnings: FC<PersonLearningsProps> = ({ personId }) => {
   const {
     learnings,
     createLearning,
@@ -72,7 +68,6 @@ const PersonLearnings: FC<PersonLearningsProps> = ({
           map(getTextFromEditorJsonContent)
         )(learnings)
       }
-      accordionSelectedValue={accordionSelectedValue}
     >
       <div className="mb-2 space-y-2">
         <Button size="sm" className="gap-1" onClick={handleCreate}>

--- a/components/people/PersonNotes.tsx
+++ b/components/people/PersonNotes.tsx
@@ -8,14 +8,9 @@ import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem"
 type PersonNotesProps = {
   personId: string;
   showNotes?: boolean;
-  accordionSelectedValue?: string;
 };
 
-const PersonNotes: FC<PersonNotesProps> = ({
-  showNotes,
-  accordionSelectedValue,
-  personId,
-}) => {
+const PersonNotes: FC<PersonNotesProps> = ({ showNotes, personId }) => {
   const { activities } = usePersonActivities(personId);
   const { getProjectNamesByIds } = useProjectsContext();
 
@@ -30,7 +25,6 @@ const PersonNotes: FC<PersonNotesProps> = ({
         )(activities),
       ]}
       isVisible={!!showNotes}
-      accordionSelectedValue={accordionSelectedValue}
     >
       {activities?.map((a) => (
         <ActivityComponent

--- a/components/projects/ProjectAccordionItem.tsx
+++ b/components/projects/ProjectAccordionItem.tsx
@@ -10,14 +10,12 @@ import ProjectDetails from "../ui-elements/project-details/project-details";
 
 type ProjectAccordionItemProps = {
   project?: Project;
-  accordionSelectedValue?: string;
   showNotes?: boolean;
   onDelete?: () => void;
 };
 
 const ProjectAccordionItem: FC<ProjectAccordionItemProps> = ({
   project,
-  accordionSelectedValue,
   onDelete,
   showNotes = true,
 }) => {
@@ -31,7 +29,6 @@ const ProjectAccordionItem: FC<ProjectAccordionItemProps> = ({
         triggerTitle={project.project}
         className="tracking-tight"
         onDelete={onDelete}
-        accordionSelectedValue={accordionSelectedValue}
         link={`/projects/${project.id}`}
         hasOpenTasks={openTasksByProjectId(project.id).length > 0}
         triggerSubTitle={[

--- a/components/territories/TerritoryDetails.tsx
+++ b/components/territories/TerritoryDetails.tsx
@@ -3,7 +3,7 @@ import {
   makeCurrentResponsibilityText,
   useTerritory,
 } from "@/api/useTerritories";
-import { FC, useState } from "react";
+import { FC } from "react";
 import AccountsList from "../accounts/AccountsList";
 import CrmLink from "../crm/CrmLink";
 import ResponsibilityDateRangeList from "../responsibility-date-ranges/ResponsibilityDateRangeList";
@@ -28,9 +28,6 @@ const TerritoryDetails: FC<TerritoryDetailsProps> = ({
   const { territory, deleteResponsibility, updateTerritory } =
     useTerritory(territoryId);
   const { accounts } = useAccountsContext();
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
 
   return !territory ? (
     "Loading territory…"
@@ -51,19 +48,11 @@ const TerritoryDetails: FC<TerritoryDetailsProps> = ({
         )}
       </div>
 
-      <Accordion
-        type="single"
-        collapsible
-        value={accordionValue}
-        onValueChange={(val) =>
-          setAccordionValue(val === accordionValue ? undefined : val)
-        }
-      >
+      <Accordion type="single" collapsible>
         <DefaultAccordionItem
           value="accounts"
           triggerTitle="Accounts"
           triggerSubTitle={territory.accounts.map((a) => a.name)}
-          accordionSelectedValue={accordionValue}
         >
           {accounts && (
             <AccountsList
@@ -81,7 +70,6 @@ const TerritoryDetails: FC<TerritoryDetailsProps> = ({
           triggerTitle="Responsibilities"
           triggerSubTitle={makeCurrentResponsibilityText(territory)}
           isVisible={!!showResponsibilities}
-          accordionSelectedValue={accordionValue}
         >
           <ResponsibilityDateRangeList
             responsibilities={territory.responsibilities}

--- a/components/territories/TerritoryList.tsx
+++ b/components/territories/TerritoryList.tsx
@@ -17,7 +17,6 @@ type ShowCurrentOrInvalid = ShowInvalidOnly | ShowCurrentOnly;
 
 type TerritoryListProps = ShowCurrentOrInvalid & {
   territories: Territory[];
-  selectedAccordionItem?: string;
 };
 
 const filterCurrentOrInvalid =
@@ -33,7 +32,6 @@ const TerritoryList: FC<TerritoryListProps> = ({
   showCurrentOnly,
   showInvalidOnly,
   territories,
-  selectedAccordionItem,
 }) => {
   return territories.filter(
     filterCurrentOrInvalid(showCurrentOnly, showInvalidOnly)
@@ -51,7 +49,6 @@ const TerritoryList: FC<TerritoryListProps> = ({
               ...t.accounts.map((a) => a.name),
               makeCurrentResponsibilityText(t),
             ]}
-            accordionSelectedValue={selectedAccordionItem}
           >
             <TerritoryDetails territoryId={t.id} />
           </DefaultAccordionItem>

--- a/components/ui-elements/accordion/DefaultAccordionItem.tsx
+++ b/components/ui-elements/accordion/DefaultAccordionItem.tsx
@@ -7,7 +7,6 @@ import {
 } from "@/components/ui/accordion";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
-import { cn } from "@/lib/utils";
 import { AccordionItemProps } from "@radix-ui/react-accordion";
 import { filter, flow, join } from "lodash/fp";
 import { CheckCircle2, Circle, Trash2 } from "lucide-react";
@@ -19,7 +18,6 @@ interface DefaultAccordionItemProps extends AccordionItemProps {
   triggerTitle: ReactNode;
   link?: string;
   triggerSubTitle?: string | boolean | (string | undefined | boolean)[];
-  accordionSelectedValue?: string;
   isVisible?: boolean;
   onDelete?: () => void;
   hasOpenTasks?: boolean;
@@ -36,7 +34,6 @@ const DefaultAccordionItem = forwardRef<
       triggerTitle,
       link,
       triggerSubTitle,
-      accordionSelectedValue,
       className,
       children,
       onDelete,
@@ -50,13 +47,10 @@ const DefaultAccordionItem = forwardRef<
     isVisible && (
       <AccordionItem value={value} ref={ref} {...props}>
         <AccordionTrigger className={className}>
-          <AccordionTriggerTitle
-            className="pr-2"
-            isOpen={accordionSelectedValue === value}
-          >
+          <AccordionTriggerTitle>
             {hasOpenTasks && (
               <>
-                <Circle className="md:hidden bg-destructive rounded-full text-destructive-foreground" />
+                <Circle className="mt-[0.2rem] w-4 h-4 md:hidden bg-destructive rounded-full text-destructive-foreground" />
                 <Badge variant="destructive" className="hidden md:block">
                   Open
                 </Badge>
@@ -64,15 +58,13 @@ const DefaultAccordionItem = forwardRef<
             )}
             {!hasOpenTasks && hasClosedTasks && (
               <>
-                <CheckCircle2 className="md:hidden rounded-full bg-constructive text-constructive-foreground" />
+                <CheckCircle2 className="mt-[0.2rem] w-4 h-4 md:hidden rounded-full bg-constructive text-constructive-foreground" />
                 <Badge className="hidden md:block bg-constructive text-constructive-foreground">
                   Done
                 </Badge>
               </>
             )}
-            <div className={cn(accordionSelectedValue !== value && "truncate")}>
-              {triggerTitle}
-            </div>
+            {triggerTitle}
             {link && (
               <Link
                 href={link}
@@ -98,10 +90,7 @@ const DefaultAccordionItem = forwardRef<
               </Button>
             )}
           </AccordionTriggerTitle>
-          <AccordionTriggerSubTitle
-            isOpen={!!triggerSubTitle && accordionSelectedValue !== value}
-            className="font-normal"
-          >
+          <AccordionTriggerSubTitle>
             {typeof triggerSubTitle === "string"
               ? triggerSubTitle
               : typeof triggerSubTitle === "boolean"
@@ -115,7 +104,7 @@ const DefaultAccordionItem = forwardRef<
                 )(triggerSubTitle)}
           </AccordionTriggerSubTitle>
         </AccordionTrigger>
-        <AccordionContent>{children}</AccordionContent>
+        <AccordionContent className="my-2">{children}</AccordionContent>
       </AccordionItem>
     )
 );

--- a/components/ui-elements/accordion/LoadingAccordionItem.tsx
+++ b/components/ui-elements/accordion/LoadingAccordionItem.tsx
@@ -5,28 +5,33 @@ import {
   AccordionTriggerTitle,
 } from "@/components/ui/accordion";
 import { Skeleton } from "@/components/ui/skeleton";
+import { cn } from "@/lib/utils";
 import { AccordionItemProps } from "@radix-ui/react-accordion";
 import { FC } from "react";
 
 interface LoadingAccordionItemProps extends AccordionItemProps {
   value: string;
-  withSubtitle?: boolean;
+  widthTitleRem: number;
+  widthSubTitleRem?: number;
 }
 
 const LoadingAccordionItem: FC<LoadingAccordionItemProps> = ({
   value,
-  withSubtitle,
+  widthTitleRem,
+  widthSubTitleRem,
 }) => (
   <AccordionItem value={value} disabled>
     <AccordionTrigger>
-      <AccordionTriggerTitle className="pr-2">
+      <AccordionTriggerTitle>
         <div>
-          <Skeleton className="h-5 w-96" />
+          <Skeleton className={cn("h-5", `w-[${widthTitleRem}rem]`)} />
         </div>
       </AccordionTriggerTitle>
-      <AccordionTriggerSubTitle className="font-normal" isOpen={withSubtitle}>
-        <Skeleton className="mt-2 h-4 w-80" />
-      </AccordionTriggerSubTitle>
+      {widthSubTitleRem && (
+        <AccordionTriggerSubTitle>
+          <Skeleton className={cn("mt-2 h-4", `w-[${widthSubTitleRem}rem]`)} />
+        </AccordionTriggerSubTitle>
+      )}
     </AccordionTrigger>
   </AccordionItem>
 );

--- a/components/ui-elements/btn-group/btn-group.tsx
+++ b/components/ui-elements/btn-group/btn-group.tsx
@@ -5,12 +5,14 @@ type ButtonGroupProps = {
   values: string[];
   selectedValue: string;
   onSelect: (value: string) => void;
+  disabled?: boolean;
 };
 
 const ButtonGroup: FC<ButtonGroupProps> = ({
   values,
   selectedValue,
   onSelect,
+  disabled,
 }) => (
   <div
     className={`h-10 rounded-md bg-muted p-1 text-muted-foreground w-full flex flex-row justify-between`}
@@ -21,6 +23,7 @@ const ButtonGroup: FC<ButtonGroupProps> = ({
         variant={val === selectedValue ? "contextColor" : "ghost"}
         className="h-8"
         onClick={() => onSelect(val)}
+        disabled={disabled}
       >
         {val.toUpperCase()}
       </Button>
@@ -29,10 +32,3 @@ const ButtonGroup: FC<ButtonGroupProps> = ({
 );
 
 export default ButtonGroup;
-
-/**
- *     role="tablist"
-    aria-orientation="horizontal"
-    className={`h-10 rounded-md bg-muted p-1 text-muted-foreground w-full grid grid-cols-${values.length}`}
-
- */

--- a/components/ui-elements/crm-project-details/crm-project-details.tsx
+++ b/components/ui-elements/crm-project-details/crm-project-details.tsx
@@ -9,13 +9,9 @@ import CrmProjectForm from "./CrmProjectForm";
 
 type CrmProjectDetailsProps = {
   crmProjectId: string;
-  accordionSelectedValue?: string;
 };
 
-const CrmProjectDetails: FC<CrmProjectDetailsProps> = ({
-  crmProjectId,
-  accordionSelectedValue,
-}) => {
+const CrmProjectDetails: FC<CrmProjectDetailsProps> = ({ crmProjectId }) => {
   const { crmProject, updateCrmProject } = useCrmProject(crmProjectId);
 
   return !crmProject ? (
@@ -23,7 +19,6 @@ const CrmProjectDetails: FC<CrmProjectDetailsProps> = ({
   ) : (
     <DefaultAccordionItem
       value={crmProject.id}
-      accordionSelectedValue={accordionSelectedValue}
       triggerTitle={crmProject.name}
       link={
         crmProject.crmId && crmProject.crmId.length > 6

--- a/components/ui-elements/crm-project-details/crm-projects-list.tsx
+++ b/components/ui-elements/crm-project-details/crm-projects-list.tsx
@@ -4,29 +4,24 @@ import useCrmProjects from "@/api/useCrmProjects";
 import { Accordion } from "@/components/ui/accordion";
 import { useContextContext } from "@/contexts/ContextContext";
 import { getRevenue2Years } from "@/helpers/projects";
-import { FC, useState } from "react";
+import { FC } from "react";
 import DefaultAccordionItem from "../accordion/DefaultAccordionItem";
 import CrmProjectForm from "./CrmProjectForm";
 import CrmProjectDetails from "./crm-project-details";
 
 type CrmProjectsListProps = {
-  accordionSelectedValue?: string;
   isVisible?: boolean;
   crmProjects: CrmProjectData[];
   projectId?: string;
 };
 
 const CrmProjectsList: FC<CrmProjectsListProps> = ({
-  accordionSelectedValue,
   isVisible,
   crmProjects,
   projectId,
 }) => {
   const { isWorkContext } = useContextContext();
   const { createCrmProject } = useCrmProjects();
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
 
   const onCrmProjectCreate = async ({
     arr,
@@ -58,7 +53,6 @@ const CrmProjectsList: FC<CrmProjectsListProps> = ({
       <DefaultAccordionItem
         value="crmprojects"
         triggerTitle="CRM Projects"
-        accordionSelectedValue={accordionSelectedValue}
         isVisible={isVisible}
         triggerSubTitle={
           crmProjects && crmProjects.length > 0 && getRevenue2Years(crmProjects)
@@ -67,19 +61,11 @@ const CrmProjectsList: FC<CrmProjectsListProps> = ({
         <CrmProjectForm onCreate={onCrmProjectCreate} />
         <div className="mb-2" />
 
-        <Accordion
-          type="single"
-          collapsible
-          value={accordionValue}
-          onValueChange={(val) =>
-            setAccordionValue(val === accordionValue ? undefined : val)
-          }
-        >
+        <Accordion type="single" collapsible>
           {crmProjects.map((crmProject) => (
             <CrmProjectDetails
               key={crmProject.id}
               crmProjectId={crmProject.id}
-              accordionSelectedValue={accordionValue}
             />
           ))}
         </Accordion>

--- a/components/ui-elements/project-details/next-action.tsx
+++ b/components/ui-elements/project-details/next-action.tsx
@@ -7,14 +7,12 @@ import DefaultAccordionItem from "../accordion/DefaultAccordionItem";
 
 type NextActionProps = {
   openTask: OpenTask;
-  accordionSelectedValue?: string;
   showProjects?: boolean;
   showMeeting?: boolean;
 };
 
 const NextAction: FC<NextActionProps> = ({
   openTask: { activityId, index, openTask, projectIds },
-  accordionSelectedValue,
   showMeeting,
   showProjects,
 }) => {
@@ -27,7 +25,6 @@ const NextAction: FC<NextActionProps> = ({
       triggerSubTitle={
         showProjects && projectIds && getProjectNamesByIds(projectIds)
       }
-      accordionSelectedValue={accordionSelectedValue}
     >
       <ActivityComponent
         activityId={activityId}

--- a/components/ui-elements/project-details/next-actions.tsx
+++ b/components/ui-elements/project-details/next-actions.tsx
@@ -24,45 +24,26 @@ type NextActionsProps = {
   projectId: string;
   own?: EditorJsonContent | string;
   others?: EditorJsonContent | string;
-  accordionSelectedValue?: string;
 };
 
-const NextActions: FC<NextActionsProps> = ({
-  projectId,
-  own,
-  others,
-  accordionSelectedValue,
-}) => {
+const NextActions: FC<NextActionsProps> = ({ projectId, own, others }) => {
   const { openTasksByProjectId } = useOpenTasksContext();
   const [openTasks] = useState(openTasksByProjectId(projectId));
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
 
   return (
     <DefaultAccordionItem
       value="next-actions"
       triggerTitle="Next Actions"
-      accordionSelectedValue={accordionSelectedValue}
       triggerSubTitle={openTasks.map(({ openTask }) =>
         getTextFromEditorJsonContent(openTask)
       )}
       isVisible
     >
-      <Accordion
-        type="single"
-        collapsible
-        className="w-full"
-        value={accordionValue}
-        onValueChange={(val) =>
-          setAccordionValue(val === accordionValue ? undefined : val)
-        }
-      >
+      <Accordion type="single" collapsible>
         {openTasks?.map((openTask) => (
           <NextAction
             key={`${openTask.activityId}-${openTask.index}`}
             openTask={openTask}
-            accordionSelectedValue={accordionValue}
             showMeeting
           />
         ))}

--- a/components/ui-elements/project-details/project-account-details.tsx
+++ b/components/ui-elements/project-details/project-account-details.tsx
@@ -36,7 +36,6 @@ const AccountName: FC<AccountNameProps> = ({
 
 type ProjectAccountDetailsProps = {
   isVisible?: boolean;
-  accordionSelectedValue?: string;
   accountIds: string[];
   onRemoveAccount: (accountId: string, accountName: string) => void;
   onAddAccount: (accountId: string | null) => void;
@@ -44,7 +43,6 @@ type ProjectAccountDetailsProps = {
 
 const ProjectAccountDetails: FC<ProjectAccountDetailsProps> = ({
   isVisible,
-  accordionSelectedValue,
   accountIds,
   onRemoveAccount,
   onAddAccount,
@@ -58,7 +56,6 @@ const ProjectAccountDetails: FC<ProjectAccountDetailsProps> = ({
         isVisible={isVisible}
         value="accounts"
         triggerTitle="Accounts"
-        accordionSelectedValue={accordionSelectedValue}
         triggerSubTitle={flow(
           map(getAccountById),
           map(get("name"))

--- a/components/ui-elements/project-details/project-activities.tsx
+++ b/components/ui-elements/project-details/project-activities.tsx
@@ -6,13 +6,11 @@ import { FC } from "react";
 import DefaultAccordionItem from "../accordion/DefaultAccordionItem";
 
 type ProjectActivitiesProps = {
-  accordionSelectedValue?: string;
   project?: Project;
   isVisible?: boolean;
 };
 
 const ProjectActivities: FC<ProjectActivitiesProps> = ({
-  accordionSelectedValue,
   project,
   isVisible,
 }) => {
@@ -23,7 +21,6 @@ const ProjectActivities: FC<ProjectActivitiesProps> = ({
     <DefaultAccordionItem
       value="activities"
       triggerTitle="Notes"
-      accordionSelectedValue={accordionSelectedValue}
       isVisible={isVisible}
     >
       <div className="space-y-2">

--- a/components/ui-elements/project-details/project-dates.tsx
+++ b/components/ui-elements/project-details/project-dates.tsx
@@ -30,18 +30,15 @@ type ProjectDatesProps = {
     onHoldTill?: Date;
     doneOn?: Date;
   }) => Promise<string | undefined>;
-  accordionSelectedValue?: string;
 };
 
 const ProjectDates: FC<ProjectDatesProps> = ({
   project: { dueOn, doneOn, onHoldTill },
   updateDatesFn,
-  accordionSelectedValue,
 }) => (
   <DefaultAccordionItem
     value="project-dates"
     triggerTitle="Project Dates"
-    accordionSelectedValue={accordionSelectedValue}
     isVisible
     triggerSubTitle={[
       doneOn && `Done on: ${format(doneOn, "PPP")}`,

--- a/components/ui-elements/project-details/project-details.tsx
+++ b/components/ui-elements/project-details/project-details.tsx
@@ -38,9 +38,6 @@ const ProjectDetails: FC<ProjectDetailsProps> = ({
     projectId ? getProjectById(projectId) : undefined
   );
   const [projectContext, setProjectContext] = useState(project?.context);
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
 
   useEffect(() => {
     setProject(getProjectById(projectId));
@@ -85,19 +82,10 @@ const ProjectDetails: FC<ProjectDetailsProps> = ({
           </RecordDetails>
         )}
 
-        <Accordion
-          type="single"
-          collapsible
-          className="w-full"
-          value={accordionValue}
-          onValueChange={(val) =>
-            setAccordionValue(val === accordionValue ? undefined : val)
-          }
-        >
+        <Accordion type="single" collapsible>
           <ProjectAccountDetails
             accountIds={project.accountIds}
             onAddAccount={handleSelectAccount}
-            accordionSelectedValue={accordionValue}
             isVisible={includeAccounts}
             onRemoveAccount={(accountId, accountName) =>
               removeAccountFromProject(
@@ -112,28 +100,18 @@ const ProjectDetails: FC<ProjectDetailsProps> = ({
           <CrmProjectsList
             crmProjects={project.crmProjects}
             isVisible={showCrmDetails}
-            accordionSelectedValue={accordionValue}
             projectId={project.id}
           />
 
-          <ProjectDates
-            project={project}
-            updateDatesFn={handleDateChange}
-            accordionSelectedValue={accordionValue}
-          />
+          <ProjectDates project={project} updateDatesFn={handleDateChange} />
 
           <NextActions
             projectId={project.id}
             own={project.myNextActions}
             others={project.othersNextActions}
-            accordionSelectedValue={accordionValue}
           />
 
-          <ProjectActivities
-            accordionSelectedValue={accordionValue}
-            isVisible={showNotes}
-            project={project}
-          />
+          <ProjectActivities isVisible={showNotes} project={project} />
         </Accordion>
       </div>
     )

--- a/components/ui-elements/project-notes-form/project-notes-form.tsx
+++ b/components/ui-elements/project-notes-form/project-notes-form.tsx
@@ -33,9 +33,6 @@ const ProjectNotesForm: FC<ProjectNotesFormProps> = ({
   const { mutateOpenTasks } = useOpenTasksContext();
   const { activity, updateNotes, isLoadingActivity, deleteProjectActivity } =
     useActivity(activityId);
-  const [accordionValue, setAccordionValue] = useState<string | undefined>(
-    undefined
-  );
   const [openDeleteActivityConfirmation, setOpenDeleteActivityConfirmation] =
     useState(false);
 
@@ -77,16 +74,13 @@ const ProjectNotesForm: FC<ProjectNotesFormProps> = ({
         }
         onConfirm={deleteActivity}
       />
-      <Accordion
-        type="single"
-        collapsible
-        value={accordionValue}
-        onValueChange={(val) =>
-          setAccordionValue(val === accordionValue ? undefined : val)
-        }
-      >
+      <Accordion type="single" collapsible>
         {isLoadingActivity ? (
-          <LoadingAccordionItem value="loading-project" withSubtitle />
+          <LoadingAccordionItem
+            value="loading-project"
+            widthTitleRem={24}
+            widthSubTitleRem={20}
+          />
         ) : !activity ? (
           <Alert>
             <AlertCircle className="h-4 w-4" />
@@ -102,7 +96,6 @@ const ProjectNotesForm: FC<ProjectNotesFormProps> = ({
                 else deleteProjectActivity(activity.projectActivityIds[index]);
               }}
               project={getProjectById(id)}
-              accordionSelectedValue={accordionValue}
             />
           ))
         )}

--- a/components/ui-elements/selectors/people-selector.tsx
+++ b/components/ui-elements/selectors/people-selector.tsx
@@ -7,12 +7,14 @@ type PeopleSelectorProps = {
   onChange: (personId: string | null) => void;
   allowNewPerson?: boolean;
   placeholder?: string;
+  disabled?: boolean;
 };
 
 const PeopleSelector: FC<PeopleSelectorProps> = ({
   value,
   onChange,
   allowNewPerson,
+  disabled,
   placeholder = "Search person…",
 }) => {
   const { people, createPerson } = usePeople();
@@ -33,6 +35,7 @@ const PeopleSelector: FC<PeopleSelectorProps> = ({
         value: id,
         label: name,
       }))}
+      disabled={disabled}
     />
   );
 };

--- a/components/ui-elements/selectors/project-selector.tsx
+++ b/components/ui-elements/selectors/project-selector.tsx
@@ -8,12 +8,14 @@ type ProjectSelectorProps = {
   allowCreateProjects?: boolean;
   onChange: (projectId: string | null) => void;
   placeholder?: string;
+  disabled?: boolean;
 };
 
 const ProjectSelector: FC<ProjectSelectorProps> = ({
   allowCreateProjects,
   value,
   onChange,
+  disabled,
   placeholder = "Search project…",
 }) => {
   const { projects, createProject } = useProjectsContext();
@@ -46,6 +48,7 @@ const ProjectSelector: FC<ProjectSelectorProps> = ({
       noSearchResultMsg="No project found."
       onChange={onChange}
       onCreate={allowCreateProjects ? onCreate : undefined}
+      disabled={disabled}
     />
   );
 };

--- a/components/ui/accordion.tsx
+++ b/components/ui/accordion.tsx
@@ -4,17 +4,7 @@ import * as React from "react";
 
 import { cn } from "@/lib/utils";
 
-const Accordion = React.forwardRef<
-  React.ElementRef<typeof AccordionPrimitive.Root>,
-  React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Root>
->(({ className, ...props }, ref) => (
-  <AccordionPrimitive.Root
-    ref={ref}
-    className={cn("w-full", className)}
-    {...props}
-  />
-));
-Accordion.displayName = "Accordion";
+const Accordion = AccordionPrimitive.Root;
 
 const AccordionItem = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Item>,
@@ -32,31 +22,30 @@ const AccordionTrigger = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Trigger>,
   React.ComponentPropsWithoutRef<typeof AccordionPrimitive.Trigger>
 >(({ className, children, ...props }, ref) => (
-  <AccordionPrimitive.Header className="flex flex-row items-center justify-between hover:bg-muted px-2 md:px-4 py-4 w-full">
+  <AccordionPrimitive.Header className="flex hover:bg-muted w-full">
     <AccordionPrimitive.Trigger
       ref={ref}
       className={cn(
-        "font-bold truncate transition-all [&[data-state=open]>svg]:rotate-180 w-full",
+        "font-bold truncate transition-all w-full flex items-center justify-between px-1 md:px-2 py-4 group",
+        "[&[data-state=open]>svg]:rotate-180",
         className
       )}
       {...props}
     >
-      {children}
+      <div className="flex flex-col flex-1 overflow-hidden">{children}</div>
+      <ChevronDown className="h-4 w-4 ml-2 flex-shrink-0 transition-transform duration-200" />
     </AccordionPrimitive.Trigger>
-    <ChevronDown className="h-4 w-4 shrink-0 transition-transform duration-200" />
   </AccordionPrimitive.Header>
 ));
 AccordionTrigger.displayName = AccordionPrimitive.Trigger.displayName;
 
 const AccordionTriggerTitle: React.FC<{
   children: React.ReactNode;
-  isOpen?: boolean;
   className?: string;
-}> = ({ children, className, isOpen }) => (
+}> = ({ children, className }) => (
   <div
     className={cn(
-      !isOpen && "flex flex-row gap-2 truncate",
-      isOpen && "flex flex-row gap-2 text-wrap text-left",
+      "flex flex-row gap-2 pr-2 truncate group-data-[state=open]:text-wrap group-data-[state=open]:text-left",
       className
     )}
   >
@@ -66,14 +55,18 @@ const AccordionTriggerTitle: React.FC<{
 
 const AccordionTriggerSubTitle: React.FC<{
   children: React.ReactNode;
-  isOpen?: boolean;
   className?: string;
-}> = ({ children, isOpen, className }) =>
-  isOpen && (
-    <div className={cn("text-sm flex flex-row gap-2 truncate", className)}>
-      {children}
-    </div>
-  );
+}> = ({ children, className }) => (
+  <div
+    className={cn(
+      "font-normal text-sm flex flex-row gap-2 truncate",
+      "group-data-[state=open]:hidden",
+      className
+    )}
+  >
+    {children}
+  </div>
+);
 
 const AccordionContent = React.forwardRef<
   React.ElementRef<typeof AccordionPrimitive.Content>,
@@ -81,7 +74,7 @@ const AccordionContent = React.forwardRef<
 >(({ className, children, ...props }, ref) => (
   <AccordionPrimitive.Content
     ref={ref}
-    className="px-2 md:px-4 py-2 space-y-2 overflow-hidden transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
+    className="overflow-hidden text-sm transition-all data-[state=closed]:animate-accordion-up data-[state=open]:animate-accordion-down"
     {...props}
   >
     <div className={cn("pb-4 pt-0", className)}>{children}</div>

--- a/components/ui/command.tsx
+++ b/components/ui/command.tsx
@@ -27,7 +27,10 @@ const CommandDialog = ({ children, ...props }: CommandDialogProps) => {
   return (
     <Dialog {...props}>
       <DialogContent className="overflow-hidden p-0 shadow-lg">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        <Command
+          loop
+          className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5"
+        >
           {children}
         </Command>
       </DialogContent>

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -4,19 +4,6 @@
 - Bei Meetings wird nun klar darauf hingewiesen, dass ein Projekt hinzugefügt werden muss, damit Notizen aufgezeichnet werden können.
 - Meetings können gelöscht werden.
 - Verwendung des Accordions vereinfacht, so dass zukünftig weniger Konfiguration dafür vorgenommen werden muss und mehr aus dem Standard kommt (mehr CSS weniger JS).
-
-## In Arbeit
-
-- Sicherstellen, dass die Browser-Historie sauber ist (ist durch `router.replace()` nicht mehr gegeben).
-
-## Geplant
-
-- In der Navigation darauf verweisen, mit welcher Tastenkombination das Menü geöffnet werden kann.
-- In der Navigation ermöglichen, dass Einträge in einem neuen Tab geöffnet werden können und dazu auch einen Hinweis im Footer geben.
-- Erstellen neuer Personen im Notizen-Feld möglich machen.
-- Loopen im Navigationsmenü ermöglichen.
-
-## Nice to have für dieses Release
-
-- Daten in meinen privaten Account verschieben.
-- Eine passende Domäne für das Projekt finden.
+- Die Browser-Historie ist wieder sauber.
+- Im Navigationsmenü können nun Einträge auch in einem neuen Tab geöffnet werden.
+- Im Navigationsmenü ist es möglich zu loopen. Wenn man also unten angekommen ist und weiter nach unten geht, landet man wieder am Anfang der Liste und umgekehrt.

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,3 +1,22 @@
-# Crash der Applikation, wenn Bilder in Sub-Elementen auftauchen (Version :VERSION)
+# UI auf weitere Personen vorbereiten (Version :VERSION)
 
-Ist behoben
+- Bei Meetings wird klarer angezeigt, wenn Daten aus dem Backend geladen werden.
+- Bei Meetings wird nun klar darauf hingewiesen, dass ein Projekt hinzugefügt werden muss, damit Notizen aufgezeichnet werden können.
+- Meetings können gelöscht werden.
+- Verwendung des Accordions vereinfacht, so dass zukünftig weniger Konfiguration dafür vorgenommen werden muss und mehr aus dem Standard kommt (mehr CSS weniger JS).
+
+## In Arbeit
+
+- Sicherstellen, dass die Browser-Historie sauber ist (ist durch `router.replace()` nicht mehr gegeben).
+
+## Geplant
+
+- In der Navigation darauf verweisen, mit welcher Tastenkombination das Menü geöffnet werden kann.
+- In der Navigation ermöglichen, dass Einträge in einem neuen Tab geöffnet werden können und dazu auch einen Hinweis im Footer geben.
+- Erstellen neuer Personen im Notizen-Feld möglich machen.
+- Loopen im Navigationsmenü ermöglichen.
+
+## Nice to have für dieses Release
+
+- Daten in meinen privaten Account verschieben.
+- Eine passende Domäne für das Projekt finden.

--- a/helpers/keyboard-events/main-layout.ts
+++ b/helpers/keyboard-events/main-layout.ts
@@ -7,22 +7,30 @@ export const addKeyDownListener = (
   toggleNavMenu: () => void,
   openCreateInboxItemDialog: () => void
 ) => {
+  const routeToUrl = (url: string) => (isMetaKeyPressed: boolean) => {
+    if (isMetaKeyPressed) window.open(url, "_blank");
+    else router.push(url);
+  };
+
+  const switchContext = (context: Context) => (isMetaKeyPressed: boolean) =>
+    !isMetaKeyPressed && setContext(context);
+
   const handleKeyDown = (event: KeyboardEvent) => {
-    if (event.ctrlKey && !event.metaKey && !event.altKey && !event.shiftKey) {
-      const func = {
-        t: () => router.replace("/today"),
-        m: () => router.replace("/meetings"),
-        c: () => router.replace("/crm-projects"),
-        p: () => router.replace("/projects"),
-        a: () => router.replace("/accounts"),
-        i: () => router.replace("/inbox"),
-        w: () => setContext("work"),
-        h: () => setContext("hobby"),
-        f: () => setContext("family"),
+    if (event.ctrlKey && !event.altKey && !event.shiftKey) {
+      const func: ((isMetaKeyPressed: boolean) => void) | undefined = {
+        t: routeToUrl("/today"),
+        m: routeToUrl("/meetings"),
+        c: routeToUrl("/crm-projects"),
+        p: routeToUrl("/projects"),
+        a: routeToUrl("/accounts"),
+        i: routeToUrl("/inbox"),
+        w: switchContext("work"),
+        h: switchContext("hobby"),
+        f: switchContext("family"),
         "+": openCreateInboxItemDialog,
       }[event.key.toLowerCase()];
       if (func) {
-        func();
+        func(event.metaKey);
       }
     }
     if (event.metaKey && !event.ctrlKey && !event.altKey && !event.shiftKey) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "@aws-sdk/client-dynamodb": "^3.602.0",
         "@aws-sdk/credential-providers": "^3.600.0",
         "@hookform/resolvers": "^3.4.2",
-        "@radix-ui/react-accordion": "^1.1.2",
+        "@radix-ui/react-accordion": "^1.2.0",
         "@radix-ui/react-alert-dialog": "^1.0.5",
         "@radix-ui/react-avatar": "^1.0.4",
         "@radix-ui/react-checkbox": "^1.0.4",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@aws-sdk/client-dynamodb": "^3.602.0",
     "@aws-sdk/credential-providers": "^3.600.0",
     "@hookform/resolvers": "^3.4.2",
-    "@radix-ui/react-accordion": "^1.1.2",
+    "@radix-ui/react-accordion": "^1.2.0",
     "@radix-ui/react-alert-dialog": "^1.0.5",
     "@radix-ui/react-avatar": "^1.0.4",
     "@radix-ui/react-checkbox": "^1.0.4",

--- a/pages/accounts/[id].tsx
+++ b/pages/accounts/[id].tsx
@@ -21,7 +21,7 @@ const AccountDetailPage = () => {
   }, [accountId, getAccountById]);
 
   const handleBackBtnClick = () => {
-    router.replace("/accounts");
+    router.push("/accounts");
   };
 
   return (

--- a/pages/accounts/index.tsx
+++ b/pages/accounts/index.tsx
@@ -16,7 +16,7 @@ const AccountsListPage = () => {
   const createAndOpenNewAccount = async () => {
     const account = await createAccount("New Account");
     if (!account) return;
-    router.replace(`/accounts/${account.id}`);
+    router.push(`/accounts/${account.id}`);
   };
 
   return (

--- a/pages/meetings/[id].tsx
+++ b/pages/meetings/[id].tsx
@@ -1,14 +1,17 @@
 import useMeeting from "@/api/useMeeting";
 import MainLayout from "@/components/layouts/MainLayout";
 import MeetingRecord from "@/components/meetings/meeting";
+import DeleteWarning from "@/components/ui-elements/project-notes-form/DeleteWarning";
 import { debouncedUpdateMeeting } from "@/helpers/meetings";
 import { useRouter } from "next/router";
+import { useState } from "react";
 
 const MeetingDetailPage = () => {
   const router = useRouter();
   const { id } = router.query;
   const meetingId: string | undefined = Array.isArray(id) ? id[0] : id;
-  const { meeting, updateMeeting } = useMeeting(meetingId);
+  const { meeting, updateMeeting, deleteMeeting } = useMeeting(meetingId);
+  const [deleteWarningOpen, setDeleteWarningOpen] = useState(false);
 
   const handleBackBtnClick = () => {
     router.replace("/meetings");
@@ -22,23 +25,27 @@ const MeetingDetailPage = () => {
 
   return (
     <MainLayout
-      title={meeting?.topic || "Loading meeting..."}
+      title={meeting?.topic}
       recordName={meeting?.topic}
       sectionName="Meetings"
       onBackBtnClick={handleBackBtnClick}
       saveTitle={saveMeetingTitle}
+      addButton={{ label: "Delete", onClick: () => setDeleteWarningOpen(true) }}
     >
-      {!meeting ? (
-        "Load meeting..."
-      ) : (
-        <MeetingRecord
-          meeting={meeting}
-          addParticipants
-          showContext
-          showMeetingDate
-          addProjects
-        />
-      )}
+      <DeleteWarning
+        open={deleteWarningOpen}
+        onOpenChange={setDeleteWarningOpen}
+        confirmText="Are you sure you want to delete the meeting?"
+        onConfirm={deleteMeeting}
+      />
+
+      <MeetingRecord
+        meeting={meeting}
+        addParticipants
+        showContext
+        showMeetingDate
+        addProjects
+      />
     </MainLayout>
   );
 };

--- a/pages/meetings/[id].tsx
+++ b/pages/meetings/[id].tsx
@@ -14,7 +14,7 @@ const MeetingDetailPage = () => {
   const [deleteWarningOpen, setDeleteWarningOpen] = useState(false);
 
   const handleBackBtnClick = () => {
-    router.replace("/meetings");
+    router.push("/meetings");
   };
 
   const saveMeetingTitle = (newTitle: string) => {

--- a/pages/meetings/index.tsx
+++ b/pages/meetings/index.tsx
@@ -36,7 +36,7 @@ export default function MeetingsPage() {
   const createAndOpenNewMeeting = async () => {
     const id = await createMeeting("New Meeting", context);
     if (!id) return;
-    router.replace(`/meetings/${id}`);
+    router.push(`/meetings/${id}`);
   };
 
   return (

--- a/pages/projects/[id].tsx
+++ b/pages/projects/[id].tsx
@@ -33,7 +33,7 @@ const ProjectDetailPage = () => {
   }, [autoFocusActivityId]);
 
   const handleBackBtnClick = () => {
-    router.replace("/projects");
+    router.push("/projects");
   };
 
   const updateProjectName = (newName: string) => {

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -17,7 +17,7 @@ const ProjectListPage = () => {
   const createAndOpenNewProject = async () => {
     const project = await createProject("New Project");
     if (!project) return;
-    router.replace(`/projects/${project.id}`);
+    router.push(`/projects/${project.id}`);
   };
 
   const onFilterChange = (newFilter: string) =>

--- a/pages/territories/[id].tsx
+++ b/pages/territories/[id].tsx
@@ -12,7 +12,7 @@ const TerritoryDetailPage = () => {
   const [formOpen, setFormOpen] = useState(false);
 
   const handleBackBtnClick = () => {
-    router.replace("/territories");
+    router.push("/territories");
   };
 
   return (

--- a/pages/territories/index.tsx
+++ b/pages/territories/index.tsx
@@ -16,7 +16,7 @@ const TerritoryListPage = () => {
   const createAndOpenTerritory = async () => {
     const territory = await createTerritory("New Territory");
     if (!territory) return;
-    router.replace(`/territories/${territory}`);
+    router.push(`/territories/${territory}`);
   };
 
   return (

--- a/pages/territories/index.tsx
+++ b/pages/territories/index.tsx
@@ -8,17 +8,9 @@ import {
 } from "@/components/ui/accordion";
 import { AccordionItem } from "@radix-ui/react-accordion";
 import { useRouter } from "next/router";
-import { useState } from "react";
 
 const TerritoryListPage = () => {
   const { territories, createTerritory } = useTerritories();
-  const [validSelectedTerritory, setValidSelectedTerritory] = useState<
-    string | undefined
-  >(undefined);
-  const [invalidSelectedTerritory, setInvalidSelectedTerritory] = useState<
-    string | undefined
-  >(undefined);
-
   const router = useRouter();
 
   const createAndOpenTerritory = async () => {
@@ -37,21 +29,8 @@ const TerritoryListPage = () => {
         "Loading territories…"
       ) : (
         <div>
-          <Accordion
-            type="single"
-            collapsible
-            value={validSelectedTerritory}
-            onValueChange={(val) =>
-              setValidSelectedTerritory(
-                val === validSelectedTerritory ? undefined : val
-              )
-            }
-          >
-            <TerritoryList
-              territories={territories}
-              showCurrentOnly
-              selectedAccordionItem={validSelectedTerritory}
-            />
+          <Accordion type="single" collapsible>
+            <TerritoryList territories={territories} showCurrentOnly />
           </Accordion>
           <div className="mt-8" />
           <Accordion type="single" collapsible>
@@ -60,21 +39,8 @@ const TerritoryListPage = () => {
                 Show territories with no current responsibility
               </AccordionTrigger>
               <AccordionContent>
-                <Accordion
-                  type="single"
-                  collapsible
-                  value={invalidSelectedTerritory}
-                  onValueChange={(val) =>
-                    setInvalidSelectedTerritory(
-                      val === invalidSelectedTerritory ? undefined : val
-                    )
-                  }
-                >
-                  <TerritoryList
-                    territories={territories}
-                    showInvalidOnly
-                    selectedAccordionItem={invalidSelectedTerritory}
-                  />
+                <Accordion type="single" collapsible>
+                  <TerritoryList territories={territories} showInvalidOnly />
                 </Accordion>
               </AccordionContent>
             </AccordionItem>


### PR DESCRIPTION
- Bei Meetings wird klarer angezeigt, wenn Daten aus dem Backend geladen werden.
- Bei Meetings wird nun klar darauf hingewiesen, dass ein Projekt hinzugefügt werden muss, damit Notizen aufgezeichnet werden können.
- Meetings können gelöscht werden.
- Verwendung des Accordions vereinfacht, so dass zukünftig weniger Konfiguration dafür vorgenommen werden muss und mehr aus dem Standard kommt (mehr CSS weniger JS).
- Die Browser-Historie ist wieder sauber.
- Im Navigationsmenü können nun Einträge auch in einem neuen Tab geöffnet werden.
- Im Navigationsmenü ist es möglich zu loopen. Wenn man also unten angekommen ist und weiter nach unten geht, landet man wieder am Anfang der Liste und umgekehrt.