### PR TITLE
Altbestand der Nächsten Aktionen aufräumen

### DIFF
--- a/components/ui-elements/project-details/legacy-next-actions.tsx
+++ b/components/ui-elements/project-details/legacy-next-actions.tsx
@@ -1,0 +1,76 @@
+import { useProjectsContext } from "@/api/ContextProjects";
+import { Button } from "@/components/ui/button";
+import { EditorJsonContent } from "@/helpers/ui-notes-writer";
+import { FC, useEffect, useState } from "react";
+import NotesWriter from "../notes-writer/NotesWriter";
+import DeleteWarning from "../project-notes-form/DeleteWarning";
+import RecordDetails from "../record-details/record-details";
+
+type LegacyNextActionsHelperProps = {
+  title: string;
+  content?: EditorJsonContent;
+};
+
+const LegacyNextActionsHelper: FC<LegacyNextActionsHelperProps> = ({
+  title,
+  content,
+}) =>
+  content && (
+    <div>
+      <div>{title}:</div>
+      <NotesWriter readonly notes={content} />
+    </div>
+  );
+
+type LegacyNextActionsProps = {
+  projectId: string;
+};
+
+const LegacyNextActions: FC<LegacyNextActionsProps> = ({ projectId }) => {
+  const { projects, deleteLegacyNextActions } = useProjectsContext();
+  const [project, setProject] = useState(
+    projects?.find((p) => p.id === projectId)
+  );
+  const [showDeleteWarning, setShowDeleteWarning] = useState(false);
+
+  useEffect(() => {
+    setProject(projects?.find((p) => p.id === projectId));
+  }, [projects, projectId]);
+
+  return (
+    (project?.myNextActions || project?.othersNextActions) && (
+      <RecordDetails title="Legacy Next Actions" className="text-destructive">
+        <div className="flex flex-col md:flex-row gap-4 w-full p-0 m-0">
+          <DeleteWarning
+            open={showDeleteWarning}
+            onOpenChange={setShowDeleteWarning}
+            confirmText="Are you sure you want to delete the legacy next actions?"
+            onConfirm={() => deleteLegacyNextActions(projectId)}
+          />
+
+          <div>
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => setShowDeleteWarning(true)}
+            >
+              Delete
+            </Button>
+          </div>
+
+          <LegacyNextActionsHelper
+            title="Mine"
+            content={project?.myNextActions}
+          />
+
+          <LegacyNextActionsHelper
+            title="Others"
+            content={project?.othersNextActions}
+          />
+        </div>
+      </RecordDetails>
+    )
+  );
+};
+
+export default LegacyNextActions;

--- a/components/ui-elements/project-details/project-details.tsx
+++ b/components/ui-elements/project-details/project-details.tsx
@@ -105,11 +105,7 @@ const ProjectDetails: FC<ProjectDetailsProps> = ({
 
           <ProjectDates project={project} updateDatesFn={handleDateChange} />
 
-          <NextActions
-            projectId={project.id}
-            own={project.myNextActions}
-            others={project.othersNextActions}
-          />
+          <NextActions projectId={project.id} />
 
           <ProjectActivities isVisible={showNotes} project={project} />
         </Accordion>

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,9 +1,6 @@
-# UI auf weitere Personen vorbereiten (Version :VERSION)
+# Altbestand der Nächsten Aktionen aufräumen (Version :VERSION)
 
-- Bei Meetings wird klarer angezeigt, wenn Daten aus dem Backend geladen werden.
-- Bei Meetings wird nun klar darauf hingewiesen, dass ein Projekt hinzugefügt werden muss, damit Notizen aufgezeichnet werden können.
-- Meetings können gelöscht werden.
-- Verwendung des Accordions vereinfacht, so dass zukünftig weniger Konfiguration dafür vorgenommen werden muss und mehr aus dem Standard kommt (mehr CSS weniger JS).
-- Die Browser-Historie ist wieder sauber.
-- Im Navigationsmenü können nun Einträge auch in einem neuen Tab geöffnet werden.
-- Im Navigationsmenü ist es möglich zu loopen. Wenn man also unten angekommen ist und weiter nach unten geht, landet man wieder am Anfang der Liste und umgekehrt.
+- Der Albestand der Aufgaben wird nur angezeigt, wenn noch welche existieren.
+- Der Altbestand der Aufgaben wird mit voller Formatierung angezeigt (z.B. Links).
+- Wenn für ein Projekt der Altbestand an Aufgaben übertragen wurde, kann dieser mit der Schaltfläche "Delete Legacy" gelöscht werden.
+- Das Accordion "Next Actions" wird nur noch angezeigt, wenn es tatsächlich noch offene Aufgaben gibt.

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -10,7 +10,7 @@ export default function Home() {
     if (lastVisitedPage) {
       router.replace(lastVisitedPage);
     } else {
-      router.replace("/today");
+      router.replace("/meetings");
     }
   }, [router]);
 


### PR DESCRIPTION
- Der Albestand der Aufgaben wird nur angezeigt, wenn noch welche existieren.
- Der Altbestand der Aufgaben wird mit voller Formatierung angezeigt (z.B. Links).
- Wenn für ein Projekt der Altbestand an Aufgaben übertragen wurde, kann dieser mit der Schaltfläche "Delete Legacy" gelöscht werden.
- Das Accordion "Next Actions" wird nur noch angezeigt, wenn es tatsächlich noch offene Aufgaben gibt.
