### PR TITLE
Erzeugen von Einträgen über das Hauptmenü optimieren

### DIFF
--- a/api/usePerson.ts
+++ b/api/usePerson.ts
@@ -56,6 +56,8 @@ export type TPersonDetailTypes = {
   fieldLabel: TDetailLabel;
   formLabel: string;
   type: "url" | "phone" | "email" | "string";
+  buildLabel?: (label: string) => string;
+  buildLink?: (label: string) => string;
   Icon: typeof Phone;
 };
 
@@ -64,30 +66,40 @@ export const personDetailsLabels: TPersonDetailTypes[] = [
     fieldLabel: "linkedIn",
     formLabel: "LinkedIn profile",
     type: "url",
+    buildLabel: (label) =>
+      label.replace(
+        /^(https?:\/\/)?(www\.)?linkedin\.com\/(in\/[a-zA-Z0-9-]+)\/?$/,
+        "$3"
+      ),
+    buildLink: (label) => label,
     Icon: Linkedin,
   },
   {
     fieldLabel: "phonePrivate",
     formLabel: "Phone (private)",
     type: "phone",
+    buildLink: (label) => `tel:${label}`,
     Icon: Phone,
   },
   {
     fieldLabel: "phoneWork",
     formLabel: "Phone (work)",
     type: "phone",
+    buildLink: (label) => `tel:${label}`,
     Icon: Building,
   },
   {
     fieldLabel: "emailPrivate",
     formLabel: "Email (private)",
     type: "email",
+    buildLink: (label) => `mailto:${label}`,
     Icon: Mail,
   },
   {
     fieldLabel: "emailWork",
     formLabel: "Email (Work)",
     type: "email",
+    buildLink: (label) => `mailto:${label.toLowerCase()}`,
     Icon: Building,
   },
   {
@@ -106,6 +118,7 @@ export const personDetailsLabels: TPersonDetailTypes[] = [
     fieldLabel: "amazonalias",
     formLabel: "Amazon Alias",
     type: "string",
+    buildLink: (label) => `https://phonetool.amazon.com/users/${label}`,
     Icon: AtSign,
   },
 ] as const;

--- a/api/usePersonLearnings.ts
+++ b/api/usePersonLearnings.ts
@@ -118,6 +118,20 @@ const usePersonLearnings = (personId?: string) => {
     return data?.id;
   };
 
+  const updateDate = async (learningId: string, date: Date) => {
+    const updated: PersonLearning[] | undefined = learnings?.map((l) =>
+      l.id !== learningId ? l : { ...l, learnedOn: date }
+    );
+    if (updated) mutate(updated, false);
+    const { data, errors } = await client.models.PersonLearning.update({
+      id: learningId,
+      learnedOn: toISODateString(date),
+    });
+    if (errors) handleApiErrors(errors, "Updating learning's date failed");
+    if (updated) mutate(updated);
+    return data?.id;
+  };
+
   const updateLearning = async (
     learningId: string,
     learning: EditorJsonContent
@@ -147,6 +161,7 @@ const usePersonLearnings = (personId?: string) => {
     createLearning,
     deleteLearning,
     updateLearning,
+    updateDate,
     updatePrayerStatus,
   };
 };

--- a/components/learnings/LearningComponent.tsx
+++ b/components/learnings/LearningComponent.tsx
@@ -3,9 +3,10 @@ import { EditorJsonContent, getEditorContent } from "@/helpers/ui-notes-writer";
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
 import { Check, Edit, Trash2 } from "lucide-react";
-import { FC } from "react";
+import { FC, useState } from "react";
 import PrayerStatus, { TPrayerStatus } from "../prayer/PrayerStatus";
 import NotesWriter from "../ui-elements/notes-writer/NotesWriter";
+import DateSelector from "../ui-elements/selectors/date-selector";
 import { Button } from "../ui/button";
 
 type LearningComponentProps = {
@@ -15,6 +16,7 @@ type LearningComponentProps = {
   onDelete?: () => void;
   onChange: (serializer: () => { json: EditorJsonContent }) => void;
   onStatusChange: (val: TPrayerStatus) => void;
+  onDateChange: (newDate: Date) => Promise<string | undefined>;
 };
 
 const LearningComponent: FC<LearningComponentProps> = ({
@@ -23,51 +25,71 @@ const LearningComponent: FC<LearningComponentProps> = ({
   onMakeEditable,
   onDelete,
   onChange,
+  onDateChange,
   onStatusChange,
-}) => (
-  <div className="py-2 space-y-1">
-    <h3 className="text-base md:text-lg font-bold tracking-tight flex items-center gap-2">
-      {format(learning.learnedOn, "PPP")}
-      {onMakeEditable && (
-        <Button
-          variant="ghost"
-          size="icon"
-          className="text-muted-foreground"
-          onClick={onMakeEditable}
-        >
-          {editable ? (
-            <Check className="w-5 h-5" />
-          ) : (
-            <Edit className="w-5 h-5" />
-          )}
-        </Button>
-      )}
-      {editable && (
-        <Button
-          variant="ghost"
-          size="icon"
-          className="text-muted-foreground"
-          onClick={onDelete}
-          asChild
-        >
-          <Trash2 className="w-5 h-5" />
-        </Button>
-      )}
-    </h3>
-    <PrayerStatus
-      status={learning.prayerStatus}
-      onChange={onStatusChange}
-      editable={!!editable}
-    />
-    <div className={cn(!editable && "-mx-2")}>
-      <NotesWriter
-        readonly={!editable}
-        placeholder="Document what you've learned about the person…"
-        notes={learning.learning}
-        saveNotes={(editor) => onChange(getEditorContent(editor))}
+}) => {
+  const [savingDate, setSavingDate] = useState(false);
+
+  const handleDateChange = async (newDate: Date) => {
+    setSavingDate(true);
+    console.log({ newDate });
+    await onDateChange(newDate);
+    setSavingDate(false);
+  };
+
+  return (
+    <div className="py-2 space-y-1">
+      <h3 className="text-base md:text-lg font-bold tracking-tight flex items-center gap-2">
+        {editable && (
+          <DateSelector
+            date={learning.learnedOn}
+            setDate={handleDateChange}
+            bold
+            isLoading={savingDate}
+          />
+        )}
+        {!editable && format(learning.learnedOn, "PPP")}
+        {onMakeEditable && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-muted-foreground"
+            onClick={onMakeEditable}
+          >
+            {editable ? (
+              <Check className="w-5 h-5" />
+            ) : (
+              <Edit className="w-5 h-5" />
+            )}
+          </Button>
+        )}
+        {editable && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="text-muted-foreground"
+            onClick={onDelete}
+            asChild
+          >
+            <Trash2 className="w-5 h-5" />
+          </Button>
+        )}
+      </h3>
+      <PrayerStatus
+        status={learning.prayerStatus}
+        onChange={onStatusChange}
+        editable={!!editable}
       />
+      <div className={cn(!editable && "-mx-2")}>
+        <NotesWriter
+          readonly={!editable}
+          placeholder="Document what you've learned about the person…"
+          notes={learning.learning}
+          saveNotes={(editor) => onChange(getEditorContent(editor))}
+        />
+      </div>
     </div>
-  </div>
-);
+  );
+};
 
 export default LearningComponent;

--- a/components/people/PersonContactDetail.tsx
+++ b/components/people/PersonContactDetail.tsx
@@ -3,9 +3,10 @@ import {
   PersonDetail,
   TPersonDetailTypes,
 } from "@/api/usePerson";
+import { Trash2 } from "lucide-react";
+import Link from "next/link";
 import { FC } from "react";
 import PersonContactDetailsForm from "./PersonContactDetailsForm";
-import { Trash2 } from "lucide-react";
 
 type PersonContactDetailProps = {
   personDetail: PersonDetail;
@@ -26,7 +27,27 @@ const PersonContactDetail: FC<PersonContactDetailProps> = ({
     <div className="my-2">
       <div className="flex flex-row gap-2 items-center">
         <detailType.Icon className="w-5 h-5" />
-        <div className="font-semibold">{personDetail.detail}</div>
+        {detailType.buildLink ? (
+          <Link
+            href={detailType.buildLink(personDetail.detail)}
+            target={
+              !detailType.buildLink(personDetail.detail).startsWith("mailto:")
+                ? "_blank"
+                : undefined
+            }
+            className="text-blue-600 hover:underline underline-offset-2 font-semibold"
+          >
+            {!detailType.buildLabel
+              ? personDetail.detail
+              : detailType.buildLabel(personDetail.detail)}
+          </Link>
+        ) : (
+          <div className="font-semibold">
+            {!detailType.buildLabel
+              ? personDetail.detail
+              : detailType.buildLabel(personDetail.detail)}
+          </div>
+        )}
         <PersonContactDetailsForm
           personName={personName}
           onChange={onChange}

--- a/components/people/PersonContactDetails.tsx
+++ b/components/people/PersonContactDetails.tsx
@@ -2,6 +2,7 @@ import {
   Person,
   PersonContactDetailsCreateProps,
   PersonContactDetailsUpdateProps,
+  PersonDetail,
   personDetailsLabels,
 } from "@/api/usePerson";
 import { FC } from "react";
@@ -15,6 +16,16 @@ type PersonContactDetailsProps = {
   onCreate: (data: PersonContactDetailsCreateProps) => void;
   onChange: (data: PersonContactDetailsUpdateProps) => void;
   onDelete: (personDetailId: string) => void;
+};
+
+const getPersonDetailLabel = (label: string) =>
+  personDetailsLabels.find((l) => l.fieldLabel === label);
+
+const buildLabel = (personDetail: PersonDetail) => {
+  const pdLabel = getPersonDetailLabel(personDetail.label);
+  return pdLabel?.buildLabel
+    ? pdLabel.buildLabel(personDetail.detail)
+    : personDetail.detail;
 };
 
 const PersonContactDetails: FC<PersonContactDetailsProps> = ({
@@ -33,12 +44,7 @@ const PersonContactDetails: FC<PersonContactDetailsProps> = ({
     <DefaultAccordionItem
       value="person-contact-details"
       triggerTitle="Contact details"
-      triggerSubTitle={person.details.map(
-        (d) =>
-          `${
-            personDetailsLabels.find((l) => l.fieldLabel === d.label)?.formLabel
-          }: ${d.detail}`
-      )}
+      triggerSubTitle={person.details.map(buildLabel)}
     >
       <PersonContactDetailsForm personName={person.name} onCreate={onCreate} />
 

--- a/components/people/PersonLearnings.tsx
+++ b/components/people/PersonLearnings.tsx
@@ -40,6 +40,7 @@ const PersonLearnings: FC<PersonLearningsProps> = ({ personId }) => {
     createLearning,
     deleteLearning,
     updateLearning,
+    updateDate,
     updatePrayerStatus,
   } = usePersonLearnings(personId);
   const [editId, setEditId] = useState<string | null>(null);
@@ -93,6 +94,7 @@ const PersonLearnings: FC<PersonLearningsProps> = ({ personId }) => {
           }
           onDelete={() => deleteLearning(learning.id)}
           onChange={handleLearningUpdate(learning.id)}
+          onDateChange={(date) => updateDate(learning.id, date)}
           onStatusChange={(val) => updatePrayerStatus(learning.id, val)}
         />
       ))}

--- a/components/ui-elements/selectors/date-selector.tsx
+++ b/components/ui-elements/selectors/date-selector.tsx
@@ -8,7 +8,7 @@ import {
 import { toLocaleTimeString } from "@/helpers/functional";
 import { cn } from "@/lib/utils";
 import { format } from "date-fns";
-import { CalendarIcon } from "lucide-react";
+import { CalendarIcon, Loader2 } from "lucide-react";
 import { ChangeEvent, FC, useEffect, useState } from "react";
 
 type DateSelectorProps = {
@@ -19,6 +19,7 @@ type DateSelectorProps = {
   placeholder?: string;
   bold?: boolean;
   disabled?: boolean;
+  isLoading?: boolean;
 };
 
 const DateSelector: FC<DateSelectorProps> = ({
@@ -28,6 +29,7 @@ const DateSelector: FC<DateSelectorProps> = ({
   selectHours,
   bold,
   disabled,
+  isLoading,
   placeholder = "Pick a date…",
 }) => {
   const [calendarOpen, setCalendarOpen] = useState(false);
@@ -71,7 +73,7 @@ const DateSelector: FC<DateSelectorProps> = ({
       <Popover open={calendarOpen} onOpenChange={setCalendarOpen}>
         <PopoverTrigger asChild>
           <Button
-            disabled={disabled}
+            disabled={disabled || isLoading}
             variant="outline"
             className={cn(
               "w-[240px] pl-3 text-left",
@@ -80,7 +82,12 @@ const DateSelector: FC<DateSelectorProps> = ({
             )}
           >
             {date ? format(date, "PPP") : <span>{placeholder}</span>}
-            <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+            {!isLoading && (
+              <CalendarIcon className="ml-auto h-4 w-4 opacity-50" />
+            )}
+            {isLoading && (
+              <Loader2 className="ml-auto h-4 w-4 opacity-50 animate-spin" />
+            )}
           </Button>
         </PopoverTrigger>
         <PopoverContent className="w-auto p-0" align="start">

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,4 +1,9 @@
-# Sortierung der Aufgabenliste optimieren (Version :VERSION)
+# Erzeugen von Einträgen über das Hauptmenü optimieren (Version :VERSION)
 
-- Die Aufgaben sind nach Wichtigkeit der Projekte sortiert.
-- Startseite ist wieder die Aufgabenliste.
+- Über das Hauptmenü können nun Einträge erzeugt werden, die direkt die Eingabe verwenden. Der neue Eintrag kann in einem neuen Fenster geöffnet werden, wenn während der Auswahl die Command-Taste gedrückt gehalten wird.
+
+## In Arbeit
+
+- Wenn etwas über eine Person gelernt wird, kann nun auch das Datum angepasst werden.
+
+## Geplant

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,9 +1,10 @@
 # Erzeugen von Einträgen über das Hauptmenü optimieren (Version :VERSION)
 
 - Über das Hauptmenü können nun Einträge erzeugt werden, die direkt die Eingabe verwenden. Der neue Eintrag kann in einem neuen Fenster geöffnet werden, wenn während der Auswahl die Command-Taste gedrückt gehalten wird.
+- Wenn etwas über eine Person gelernt wird, kann nun auch das Datum angepasst werden.
 
 ## In Arbeit
 
-- Wenn etwas über eine Person gelernt wird, kann nun auch das Datum angepasst werden.
+- Kontaktdetails können jetzt angeklickt werden und entsprechend der Kategorie wird ein Anruf getätigt, eine E-Mail geöffnet oder eine Profilseite aufgerufen.
 
 ## Geplant

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -2,9 +2,4 @@
 
 - Über das Hauptmenü können nun Einträge erzeugt werden, die direkt die Eingabe verwenden. Der neue Eintrag kann in einem neuen Fenster geöffnet werden, wenn während der Auswahl die Command-Taste gedrückt gehalten wird.
 - Wenn etwas über eine Person gelernt wird, kann nun auch das Datum angepasst werden.
-
-## In Arbeit
-
 - Kontaktdetails können jetzt angeklickt werden und entsprechend der Kategorie wird ein Anruf getätigt, eine E-Mail geöffnet oder eine Profilseite aufgerufen.
-
-## Geplant


### PR DESCRIPTION
- Über das Hauptmenü können nun Einträge erzeugt werden, die direkt die Eingabe verwenden. Der neue Eintrag kann in einem neuen Fenster geöffnet werden, wenn während der Auswahl die Command-Taste gedrückt gehalten wird.
- Wenn etwas über eine Person gelernt wird, kann nun auch das Datum angepasst werden.
- Kontaktdetails können jetzt angeklickt werden und entsprechend der Kategorie wird ein Anruf getätigt, eine E-Mail geöffnet oder eine Profilseite aufgerufen.
