### PR TITLE
Meetingnotizen zeigen offene Aufgaben

### DIFF
--- a/components/activities/activity.tsx
+++ b/components/activities/activity.tsx
@@ -132,6 +132,8 @@ const ActivityComponent: FC<ActivityComponentProps> = ({
     <DefaultAccordionItem
       value={activityId}
       triggerTitle="Meeting notes"
+      hasOpenTasks={activity?.hasOpenTasks}
+      hasClosedTasks={!!activity?.closedTasks?.length}
       triggerSubTitle={`Projects: ${getProjectNamesByIds(
         activity?.projectIds
       )}`}

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,5 +1,3 @@
-# Erzeugen von Einträgen über das Hauptmenü optimieren (Version :VERSION)
+# Meetingnotizen zeigen offene Aufgaben (Version :VERSION)
 
-- Über das Hauptmenü können nun Einträge erzeugt werden, die direkt die Eingabe verwenden. Der neue Eintrag kann in einem neuen Fenster geöffnet werden, wenn während der Auswahl die Command-Taste gedrückt gehalten wird.
-- Wenn etwas über eine Person gelernt wird, kann nun auch das Datum angepasst werden.
-- Kontaktdetails können jetzt angeklickt werden und entsprechend der Kategorie wird ein Anruf getätigt, eine E-Mail geöffnet oder eine Profilseite aufgerufen.
+- Bei Meetings ist nun auch in den Meetingnotizen anhand eines Badges erkennbar, ob hier noch offene Aufgaben verborgen liegen oder alle dokumentierten Aufgaben erledigt sind.


### PR DESCRIPTION
- Bei Meetings ist nun auch in den Meetingnotizen anhand eines Badges erkennbar, ob hier noch offene Aufgaben verborgen liegen oder alle dokumentierten Aufgaben erledigt sind.
