### PR TITLE
Fehlerbehebungen bei CRM Projekt-Aktualisierungen

### DIFF
--- a/components/crm/import-project-data.tsx
+++ b/components/crm/import-project-data.tsx
@@ -84,6 +84,7 @@ const ImportProjectData = () => {
             (p.name !== d.name ||
               p.accountName !== d.accountName ||
               flow(diffCalDays(p.closeDate), Math.abs)(d.closeDate) > 3 ||
+              flow(diffCalDays(p.createdDate), Math.abs)(d.createdDate) > 3 ||
               p.stage !== d.stage ||
               p.arr !== d.arr ||
               p.nextStep !== d.nextStep ||

--- a/components/crm/list-filter-context.tsx
+++ b/components/crm/list-filter-context.tsx
@@ -160,11 +160,11 @@ const CrmProjectsFilterProvider: FC<CrmProjectsFilterProviderProps> = ({
             "All",
             ...enableNoProjectFilter(crmProjects),
             ...enableDifferentAccountFilter(crmProjects),
-            ...enableOtherOwnerFilter(user, crmProjects),
             ...enableDifferentPartnerFilter(crmProjects),
             ...enableUpdateDueFilter(crmProjects),
             "By Partner",
             "By Account",
+            ...enableOtherOwnerFilter(user, crmProjects),
           ] as TProjectFilters[]
         ).filter((t) => !!t)
       );

--- a/components/crm/pipeline-hygiene-category.tsx
+++ b/components/crm/pipeline-hygiene-category.tsx
@@ -1,9 +1,19 @@
 import { CrmProject } from "@/api/useCrmProjects";
+import { make2YearsRevenueText } from "@/helpers/projects";
+import { filter, flow, map, sum } from "lodash/fp";
 import { FC } from "react";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
 import CrmProjectDetails from "../ui-elements/crm-project-details/crm-project-details";
 import { Accordion } from "../ui/accordion";
 import { THygieneIssue } from "./pipeline-hygiene";
+
+export const categoryPipeline =
+  (crmProjects: CrmProject[] | undefined) => (category: THygieneIssue) =>
+    flow(
+      filter(category.filterFn),
+      map((crm) => crm.pipeline),
+      sum
+    )(crmProjects) ?? 0;
 
 type CrmProjectsPipelineHygieneCategoryProps = {
   crmProjects: CrmProject[] | undefined;
@@ -12,11 +22,18 @@ type CrmProjectsPipelineHygieneCategoryProps = {
 
 const CrmProjectsPipelineHygieneCategory: FC<
   CrmProjectsPipelineHygieneCategoryProps
-> = ({ crmProjects, hygieneCategory: { value, label, description } }) => (
+> = ({ crmProjects, hygieneCategory }) => (
   <DefaultAccordionItem
-    value={value}
-    triggerTitle={label}
-    triggerSubTitle={[`${crmProjects?.length} projects`, description]}
+    value={hygieneCategory.value}
+    triggerTitle={hygieneCategory.label}
+    triggerSubTitle={[
+      `${crmProjects?.length} projects`,
+      hygieneCategory.description,
+      flow(
+        categoryPipeline(crmProjects),
+        make2YearsRevenueText
+      )(hygieneCategory),
+    ]}
     isVisible={!!crmProjects?.length}
   >
     <Accordion type="single" collapsible>

--- a/components/crm/pipeline-hygiene.tsx
+++ b/components/crm/pipeline-hygiene.tsx
@@ -1,9 +1,12 @@
 import { TCrmStages } from "@/api/useCrmProject";
 import { CrmProject } from "@/api/useCrmProjects";
+import { invertSign } from "@/helpers/functional";
 import { differenceInCalendarDays, isFuture } from "date-fns";
-import { filter, flow, get, isFinite, map, split } from "lodash/fp";
+import { filter, flow, get, isFinite, map, sortBy, split } from "lodash/fp";
 import { FC } from "react";
-import CrmProjectsPipelineHygieneCategory from "./pipeline-hygiene-category";
+import CrmProjectsPipelineHygieneCategory, {
+  categoryPipeline,
+} from "./pipeline-hygiene-category";
 
 type FilterFunction = (crm: CrmProject) => boolean;
 
@@ -109,12 +112,15 @@ type CrmProjectsPipelineHygieneProps = {
 const CrmProjectsPipelineHygiene: FC<CrmProjectsPipelineHygieneProps> = ({
   crmProjects,
 }) =>
-  hygieneIssues.map((hygieneCategory) => (
-    <CrmProjectsPipelineHygieneCategory
-      key={hygieneCategory.value}
-      hygieneCategory={hygieneCategory}
-      crmProjects={crmProjects?.filter(hygieneCategory.filterFn)}
-    />
-  ));
+  flow(
+    sortBy(flow(categoryPipeline(crmProjects ?? undefined), invertSign)),
+    map((category) => (
+      <CrmProjectsPipelineHygieneCategory
+        key={category.value}
+        hygieneCategory={category}
+        crmProjects={crmProjects?.filter(category.filterFn)}
+      />
+    ))
+  )(hygieneIssues);
 
 export default CrmProjectsPipelineHygiene;

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,3 +1,4 @@
 # Fehlerbehebungen bei CRM Projekt-Aktualisierungen (Version :VERSION)
 
-- Geschlossene CRM Projekte werden nun noch für 30 Tage angezeigt.
+- CRM Projekte sind nach Größe der Pipeline sortiert, auch wenn nach Kunden, Partnern oder Hygiene-Themen gruppiert wird.
+- Für jeden Filter in der CRM-Projekte Listenansicht werden die Anzahl der Projekte angezeigt.

--- a/helpers/functional.ts
+++ b/helpers/functional.ts
@@ -56,3 +56,4 @@ export const truncateMiddle = (text: string, length = 20): string => {
 };
 export const diffCalDays = (date1: Date) => (date2: Date) =>
   differenceInCalendarDays(date2, date1);
+export const invertSign = (value: number) => -value;

--- a/pages/crm-projects/index.tsx
+++ b/pages/crm-projects/index.tsx
@@ -1,6 +1,7 @@
 import GroupCrmProjects from "@/components/crm/group-projects";
 import ImportProjectData from "@/components/crm/import-project-data";
 import {
+  TProjectFilters,
   useCrmProjectsFilter,
   withCrmProjectsFilter,
 } from "@/components/crm/list-filter-context";
@@ -39,6 +40,20 @@ const CrmProjectsPage = () => {
             )(10)}
 
           <ApiLoadingError title="Loading CRM Projects failed" error={error} />
+
+          {crmProjects &&
+            (
+              [
+                "All",
+                "No Project",
+                "Differenct Account",
+                "Differenct Partner",
+              ] as TProjectFilters[]
+            ).includes(selectedFilter) && (
+              <div className="font-semibold text-sm text-muted-foreground">
+                {crmProjects.length} projects.
+              </div>
+            )}
 
           {selectedFilter === "Update Due" ? (
             <CrmProjectsPipelineHygiene crmProjects={crmProjects} />


### PR DESCRIPTION
- CRM Projekte sind nach Größe der Pipeline sortiert, auch wenn nach Kunden, Partnern oder Hygiene-Themen gruppiert wird.
- Für jeden Filter in der CRM-Projekte Listenansicht werden die Anzahl der Projekte angezeigt.
