### PR TITLE
Projekte schnell verlegen

### DIFF
--- a/components/accounts/ProjectList.tsx
+++ b/components/accounts/ProjectList.tsx
@@ -23,11 +23,14 @@ type ProjectsByFilter = {
   accountId?: never;
   filter: ProjectFilters;
 };
-type ProjectListProps = ProjectsByAccount | ProjectsByFilter;
+type ProjectListProps = (ProjectsByAccount | ProjectsByFilter) & {
+  allowPushToNextDay?: boolean;
+};
 
 const ProjectList: FC<ProjectListProps> = ({
   accountId,
   filter: projectFilter,
+  allowPushToNextDay,
 }) => {
   const { projects, loadingProjects, errorProjects } = useProjectsContext();
   const { accounts } = useAccountsContext();
@@ -65,7 +68,11 @@ const ProjectList: FC<ProjectListProps> = ({
           )(10)}
 
         {filteredProjects.map((project) => (
-          <ProjectAccordionItem key={project.id} project={project} />
+          <ProjectAccordionItem
+            key={project.id}
+            project={project}
+            allowPushToNextDay={allowPushToNextDay}
+          />
         ))}
       </Accordion>
     </div>

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,3 +1,3 @@
-# Bessere Visualisierung von Akkordions (Version :VERSION)
+# Projekte schnell verlegen (Version :VERSION)
 
-- Wenn Akkordions aufgeklappt werden, erhalten sie jetzt einen leichten transparenten Hintergrund. Wenn darüber weitere Akkordions geöffnet werden, wird die Transparenz immer weniger und somit sollte sich leichter unterscheiden lassen, welcher Akkordion Kopf zu welchem Inhalt gehört.
+- In der Projekt-Listenansicht kann ich ein einzelnes Projekt schnell auf den nächsten Tag verlegen (On Hold Till), um davon nicht ständig abgelenkt zu werden.

--- a/pages/projects/index.tsx
+++ b/pages/projects/index.tsx
@@ -37,7 +37,7 @@ const ProjectListPage = () => {
           />
         </div>
 
-        <ProjectList filter={filter} />
+        <ProjectList filter={filter} allowPushToNextDay />
       </div>
     </MainLayout>
   );


### PR DESCRIPTION
- In der Projekt-Listenansicht kann ich ein einzelnes Projekt schnell auf den nächsten Tag verlegen (On Hold Till), um davon nicht ständig abgelenkt zu werden.
