### PR TITLE
Fehlerbehebungen CRM Projekte und Hauptmenü

### DIFF
--- a/api/useCrmProjectsImport.tsx
+++ b/api/useCrmProjectsImport.tsx
@@ -6,7 +6,7 @@ import {
   uploadFileToS3,
 } from "@/helpers/s3/upload-filtes";
 import { generateClient } from "aws-amplify/data";
-import { addDays } from "date-fns";
+import { addDays, min } from "date-fns";
 import { floor, flow } from "lodash/fp";
 import { ChangeEvent } from "react";
 import useSWR from "swr";
@@ -140,6 +140,7 @@ const useCrmProjectsImport = (status: TImportStatus) => {
       "Account Name": "accountName",
       Territory: "territoryName",
       "Created Date": "createdDate",
+      "System Close Date": "systemCloseDate",
     };
 
     // Iterate through the rows and build the JSON objects
@@ -163,6 +164,13 @@ const useCrmProjectsImport = (status: TImportStatus) => {
             if (key === "closeDate") {
               const [month, day, year] = value.split("/");
               value = new Date(year, month - 1, day);
+            }
+            // make 'systemCloseDate' a date
+            if (key === "systemCloseDate") {
+              if (value) {
+                const [month, day, year] = value.split("/");
+                value = new Date(year, month - 1, day);
+              }
             }
             // make 'createdDate' a date
             if (key === "createdDate") {
@@ -196,7 +204,9 @@ const useCrmProjectsImport = (status: TImportStatus) => {
           arr: obj.arr,
           tcv: 0,
           isMarketplace: false,
-          closeDate: obj.closeDate,
+          closeDate: !obj.systemCloseDate
+            ? obj.closeDate
+            : min([obj.systemCloseDate, obj.closeDate]),
           createdDate: obj.createdDate,
           projectIds: [],
           stage: obj.stage,

--- a/components/navigation-menu/SearchableDataGroup.tsx
+++ b/components/navigation-menu/SearchableDataGroup.tsx
@@ -1,3 +1,4 @@
+import { cn } from "@/lib/utils";
 import { useCommandState } from "cmdk";
 import { useRouter } from "next/router";
 import { FC } from "react";
@@ -28,17 +29,16 @@ const SearchableDataGroup: FC<SearchableDataGroupProps> = ({
   };
 
   return (
-    search &&
-    search.length >= 4 &&
-    items && (
-      <CommandGroup heading={heading}>
-        {items.map(({ id, value, link }) => (
-          <CommandItem key={id} onSelect={routeToUrl(link)}>
-            {value}
-          </CommandItem>
-        ))}
-      </CommandGroup>
-    )
+    <CommandGroup
+      heading={heading}
+      className={cn((!search || search.length < 4 || !items) && "hidden")}
+    >
+      {items?.map(({ id, value, link }) => (
+        <CommandItem key={id} onSelect={routeToUrl(link)}>
+          {value}
+        </CommandItem>
+      ))}
+    </CommandGroup>
   );
 };
 

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,3 +1,8 @@
-# Projekte schnell verlegen (Version :VERSION)
+# Fehlerbehebungen (Version :VERSION)
 
-- In der Projekt-Listenansicht kann ich ein einzelnes Projekt schnell auf den nächsten Tag verlegen (On Hold Till), um davon nicht ständig abgelenkt zu werden.
+- Es gab CRM Projekte, bei denen das Abschlussdatum weit in der Zukunft lag und das CRM Projekt bereits geschlossen ist (verloren oder gewonnen). In diesem Fall wäre das Projekt noch sehr lange und immer wieder in der Liste aufgetaucht, obwohl nichts mehr dafür getan werden konnte. Das ist nun behoben. Es wird immer das kleinere Datum für den Import herangezogen, entweder das Abschlussdatum oder das System-Abschlussdatum, das anzeigt, wann das Projekt geschlossen wurde.
+
+## In Arbeit
+
+- Den Crash im Hauptmenü fixen
+- Blöcke als einzelne Records in der Datenbank speichern.

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,4 +1,4 @@
-# Fehlerbehebungen (Version :VERSION)
+# Fehlerbehebungen CRM Projekte und Hauptmenü (Version :VERSION)
 
 - Es gab CRM Projekte, bei denen das Abschlussdatum weit in der Zukunft lag und das CRM Projekt bereits geschlossen ist (verloren oder gewonnen). In diesem Fall wäre das Projekt noch sehr lange und immer wieder in der Liste aufgetaucht, obwohl nichts mehr dafür getan werden konnte. Das ist nun behoben. Es wird immer das kleinere Datum für den Import herangezogen, entweder das Abschlussdatum oder das System-Abschlussdatum, das anzeigt, wann das Projekt geschlossen wurde.
 - Das Hauptmenü führte häufig zu Abstürzen, wenn der Suchbegriff einmal mehr als 3 Zeichen hatte und dann wieder weniger. Der Grund dafür war, dass die Gruppen als Komponenten immer erst dann erschienen, wenn die Suche mehr als 3 Zeichen hatte. CmdK kann nicht gut damit umgehen, wenn die React Komponente plötzlich wieder ganz verschwindet. Wir verstecken sie nun mit einer CSS Klasse, entfernen sie aber nicht komplett vom DOM.

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,8 +1,8 @@
 # Fehlerbehebungen (Version :VERSION)
 
 - Es gab CRM Projekte, bei denen das Abschlussdatum weit in der Zukunft lag und das CRM Projekt bereits geschlossen ist (verloren oder gewonnen). In diesem Fall wäre das Projekt noch sehr lange und immer wieder in der Liste aufgetaucht, obwohl nichts mehr dafür getan werden konnte. Das ist nun behoben. Es wird immer das kleinere Datum für den Import herangezogen, entweder das Abschlussdatum oder das System-Abschlussdatum, das anzeigt, wann das Projekt geschlossen wurde.
+- Das Hauptmenü führte häufig zu Abstürzen, wenn der Suchbegriff einmal mehr als 3 Zeichen hatte und dann wieder weniger. Der Grund dafür war, dass die Gruppen als Komponenten immer erst dann erschienen, wenn die Suche mehr als 3 Zeichen hatte. CmdK kann nicht gut damit umgehen, wenn die React Komponente plötzlich wieder ganz verschwindet. Wir verstecken sie nun mit einer CSS Klasse, entfernen sie aber nicht komplett vom DOM.
 
 ## In Arbeit
 
-- Den Crash im Hauptmenü fixen
 - Blöcke als einzelne Records in der Datenbank speichern.


### PR DESCRIPTION
- Es gab CRM Projekte, bei denen das Abschlussdatum weit in der Zukunft lag und das CRM Projekt bereits geschlossen ist (verloren oder gewonnen). In diesem Fall wäre das Projekt noch sehr lange und immer wieder in der Liste aufgetaucht, obwohl nichts mehr dafür getan werden konnte. Das ist nun behoben. Es wird immer das kleinere Datum für den Import herangezogen, entweder das Abschlussdatum oder das System-Abschlussdatum, das anzeigt, wann das Projekt geschlossen wurde.
- Das Hauptmenü führte häufig zu Abstürzen, wenn der Suchbegriff einmal mehr als 3 Zeichen hatte und dann wieder weniger. Der Grund dafür war, dass die Gruppen als Komponenten immer erst dann erschienen, wenn die Suche mehr als 3 Zeichen hatte. CmdK kann nicht gut damit umgehen, wenn die React Komponente plötzlich wieder ganz verschwindet. Wir verstecken sie nun mit einer CSS Klasse, entfernen sie aber nicht komplett vom DOM.
