### PR TITLE
Meetings weiter optimieren

### DIFF
--- a/api/ContextProjects.tsx
+++ b/api/ContextProjects.tsx
@@ -492,6 +492,7 @@ export const ProjectsContextProvider: FC<ProjectsContextProviderProps> = ({
       ? ""
       : flow(
           filter((p: Project) => projectIds.includes(p.id)),
+          filter((p) => !p.done),
           map(get("project")),
           join(", ")
         )(projects);

--- a/api/useMeeting.ts
+++ b/api/useMeeting.ts
@@ -74,6 +74,31 @@ const useMeeting = (meetingId?: string) => {
     return data?.meetingId;
   };
 
+  const getMeetingParticipantId = (personId: string) => {
+    if (!meeting) return;
+    return meeting.participantMeetingIds[
+      meeting.participantIds.findIndex((id) => id === personId)
+    ];
+  };
+
+  const removeMeetingParticipant = async (personId: string) => {
+    if (!meeting) return;
+    const updated: Meeting = {
+      ...meeting,
+      participantIds: meeting.participantIds.filter((id) => id !== personId),
+    };
+    mutateMeeting(updated, false);
+    const meetingParticipantId = getMeetingParticipantId(personId);
+    if (!meetingParticipantId) return;
+    const { data, errors } = await client.models.MeetingParticipant.delete({
+      id: meetingParticipantId,
+    });
+    if (errors)
+      handleApiErrors(errors, "Error deleting entry meeting participant");
+    mutateMeeting(updated);
+    return data?.id;
+  };
+
   const deleteMeetingActivity = async (activityId: string) => {
     if (!meeting) return;
     const updated: Meeting = {
@@ -164,6 +189,7 @@ const useMeeting = (meetingId?: string) => {
     loadingMeeting,
     updateMeeting,
     createMeetingParticipant,
+    removeMeetingParticipant,
     createMeetingActivity,
     updateMeetingContext,
     deleteMeetingActivity,

--- a/api/useMeetingProjectRecommendation.tsx
+++ b/api/useMeetingProjectRecommendation.tsx
@@ -1,0 +1,47 @@
+import { type Schema } from "@/amplify/data/resource";
+import { generateClient } from "aws-amplify/data";
+import { flatMap, flatten, flow, get, uniq } from "lodash/fp";
+import useSWR from "swr";
+import { handleApiErrors } from "./globals";
+import { Meeting } from "./useMeetings";
+const client = generateClient<Schema>();
+
+const fetchPerson = async (personId: string) => {
+  const { data, errors } = await client.models.Person.get(
+    { id: personId },
+    {
+      selectionSet: ["meetings.meeting.activities.forProjects.projectsId"],
+    }
+  );
+  if (errors) {
+    handleApiErrors(errors, "Error loading meeting project recommendations");
+    throw errors;
+  }
+  return flow(
+    get("meetings"),
+    flatMap(get("meeting.activities")),
+    flatMap(get("forProjects")),
+    flatMap(get("projectsId"))
+  )(data);
+};
+
+const fetchMeetingProjectRecommendation = (meeting?: Meeting) => async () => {
+  if (!meeting) return;
+  const data = await Promise.all(meeting.participantIds.map(fetchPerson));
+  return flow(flatten, uniq)(data) as string[] | undefined;
+};
+
+const useMeetingProjectRecommendation = (meeting?: Meeting) => {
+  const {
+    data: projectIds,
+    isLoading,
+    error,
+  } = useSWR(
+    `/api/meetings/${meeting?.id}/recommendations`,
+    fetchMeetingProjectRecommendation(meeting)
+  );
+
+  return { projectIds, isLoading, error };
+};
+
+export default useMeetingProjectRecommendation;

--- a/api/useMeetings.ts
+++ b/api/useMeetings.ts
@@ -15,6 +15,7 @@ export type Meeting = {
   topic: string;
   context?: Context;
   meetingOn: Date;
+  participantMeetingIds: string[];
   participantIds: string[];
   activities: Activity[];
 };
@@ -25,7 +26,8 @@ export const meetingSelectionSet = [
   "context",
   "meetingOn",
   "createdAt",
-  "participants.person.id",
+  "participants.id",
+  "participants.personId",
   "activities.id",
   "activities.notes",
   "activities.formatVersion",
@@ -57,7 +59,8 @@ export const mapMeeting: (data: MeetingData) => Meeting = ({
   topic,
   meetingOn: new Date(meetingOn || createdAt),
   context: context || undefined,
-  participantIds: participants.map(({ person: { id } }) => id),
+  participantMeetingIds: participants.map(({ id }) => id),
+  participantIds: participants.map(({ personId }) => personId),
   activities: flow(
     map(mapActivity),
     sortBy((a) => -a.finishedOn.getTime())
@@ -169,6 +172,7 @@ const useMeetings = ({ page = 1, context }: UseMeetingsProps) => {
       topic,
       meetingOn: new Date(),
       participantIds: [],
+      participantMeetingIds: [],
       activities: [],
     };
     const updatedMeetings = [newMeeting, ...(meetings || [])];

--- a/components/meetings/meeting-participants.tsx
+++ b/components/meetings/meeting-participants.tsx
@@ -7,11 +7,13 @@ import PeopleSelector from "../ui-elements/selectors/people-selector";
 type MeetingParticipantsProps = {
   participantIds: string[];
   addParticipant?: (personId: string | null) => void;
+  removeParticipant?: (personId: string) => void;
 };
 
 const MeetingParticipants: FC<MeetingParticipantsProps> = ({
   participantIds,
   addParticipant,
+  removeParticipant,
 }) => {
   const { getNamesByIds } = usePeople();
 
@@ -32,7 +34,11 @@ const MeetingParticipants: FC<MeetingParticipantsProps> = ({
         )}
         <div className="my-2" />
 
-        <PeopleList personIds={participantIds} showNotes={false} />
+        <PeopleList
+          personIds={participantIds}
+          showNotes={false}
+          onDelete={removeParticipant}
+        />
       </DefaultAccordionItem>
     )
   );

--- a/components/meetings/meeting-project-recommender.tsx
+++ b/components/meetings/meeting-project-recommender.tsx
@@ -1,27 +1,12 @@
 import { useAccountsContext } from "@/api/ContextAccounts";
-import { Project, useProjectsContext } from "@/api/ContextProjects";
+import { useProjectsContext } from "@/api/ContextProjects";
+import useMeetingProjectRecommendation from "@/api/useMeetingProjectRecommendation";
 import { Meeting } from "@/api/useMeetings";
-import usePersonActivities from "@/api/usePersonActivities";
-import { compact, filter, flatMap, flow, get, map, uniq } from "lodash/fp";
-import { FC, useEffect, useState } from "react";
+import { compact, filter, flatMap, flow, get, map } from "lodash/fp";
+import { FC } from "react";
 
 const filterOutProjectIds = (avoidIds: string[] | undefined) => (id: string) =>
   !avoidIds?.includes(id);
-
-const MeetingPersonActivities = (personId: string) => {
-  const { activities } = usePersonActivities(personId);
-  return activities;
-};
-
-const useMeetingActivities = (participantIds: string[] | undefined) => {
-  if (!participantIds) return undefined;
-  return flow(
-    flatMap(MeetingPersonActivities),
-    compact,
-    flatMap(get("projectIds")),
-    uniq
-  )(participantIds);
-};
 
 type MeetingProjectRecommenderProps = {
   meeting?: Meeting | undefined;
@@ -32,15 +17,16 @@ const MeetingProjectRecommender: FC<MeetingProjectRecommenderProps> = ({
   meeting,
   addProjectToMeeting,
 }) => {
-  const projectIds = useMeetingActivities(meeting?.participantIds);
+  const { projectIds } = useMeetingProjectRecommendation(meeting);
   const { getProjectById } = useProjectsContext();
   const { getAccountNamesByIds } = useAccountsContext();
-  const [projects, setProjects] = useState<Project[] | undefined>(undefined);
 
-  useEffect(() => {
-    {
-      flow(
-        compact,
+  return (
+    <div className="px-1 md:px-2 text-sm text-muted-foreground">
+      <span className="font-semibold">
+        Add these projects where participants contributed:
+      </span>
+      {flow(
         filter(
           filterOutProjectIds(
             flow(get("activities"), flatMap(get("projectIds")))(meeting)
@@ -49,27 +35,17 @@ const MeetingProjectRecommender: FC<MeetingProjectRecommenderProps> = ({
         map(getProjectById),
         compact,
         filter((p) => !p.done),
-        setProjects
-      )(projectIds);
-    }
-  }, [getProjectById, meeting, projectIds]);
-
-  return (
-    <div className="px-1 md:px-2 text-sm text-muted-foreground">
-      <span className="font-semibold">
-        Add these projects where participants contributed:
-      </span>
-      {projects?.map((p) => (
-        <span key={p.id}>
+        map(({ id, project, accountIds }) => (
           <span
+            key={id}
             className="pl-1 md:pl-2 hover:text-primary hover:underline hover:underline-offset-2 hover:cursor-pointer"
-            onClick={() => addProjectToMeeting(p.id)}
+            onClick={() => addProjectToMeeting(id)}
           >
-            {p.project}
-            {p.accountIds && ` (${getAccountNamesByIds(p.accountIds)})`}
+            {project}
+            {accountIds && ` (${getAccountNamesByIds(accountIds)})`}
           </span>
-        </span>
-      ))}
+        ))
+      )(projectIds)}
     </div>
   );
 };

--- a/components/meetings/meeting-project-recommender.tsx
+++ b/components/meetings/meeting-project-recommender.tsx
@@ -1,0 +1,77 @@
+import { useAccountsContext } from "@/api/ContextAccounts";
+import { Project, useProjectsContext } from "@/api/ContextProjects";
+import { Meeting } from "@/api/useMeetings";
+import usePersonActivities from "@/api/usePersonActivities";
+import { compact, filter, flatMap, flow, get, map, uniq } from "lodash/fp";
+import { FC, useEffect, useState } from "react";
+
+const filterOutProjectIds = (avoidIds: string[] | undefined) => (id: string) =>
+  !avoidIds?.includes(id);
+
+const MeetingPersonActivities = (personId: string) => {
+  const { activities } = usePersonActivities(personId);
+  return activities;
+};
+
+const useMeetingActivities = (participantIds: string[] | undefined) => {
+  if (!participantIds) return undefined;
+  return flow(
+    flatMap(MeetingPersonActivities),
+    compact,
+    flatMap(get("projectIds")),
+    uniq
+  )(participantIds);
+};
+
+type MeetingProjectRecommenderProps = {
+  meeting?: Meeting | undefined;
+  addProjectToMeeting: (projectId: string) => void;
+};
+
+const MeetingProjectRecommender: FC<MeetingProjectRecommenderProps> = ({
+  meeting,
+  addProjectToMeeting,
+}) => {
+  const projectIds = useMeetingActivities(meeting?.participantIds);
+  const { getProjectById } = useProjectsContext();
+  const { getAccountNamesByIds } = useAccountsContext();
+  const [projects, setProjects] = useState<Project[] | undefined>(undefined);
+
+  useEffect(() => {
+    {
+      flow(
+        compact,
+        filter(
+          filterOutProjectIds(
+            flow(get("activities"), flatMap(get("projectIds")))(meeting)
+          )
+        ),
+        map(getProjectById),
+        compact,
+        filter((p) => !p.done),
+        setProjects
+      )(projectIds);
+    }
+  }, [getProjectById, meeting, projectIds]);
+
+  return (
+    <div className="px-1 md:px-2 text-sm text-muted-foreground">
+      <span className="font-semibold">
+        Add these projects where participants contributed:
+      </span>
+      {projects?.map((p) => (
+        <span key={p.id}>
+          <span
+            className="pl-1 md:pl-2 hover:text-primary hover:underline hover:underline-offset-2 hover:cursor-pointer"
+            onClick={() => addProjectToMeeting(p.id)}
+          >
+            {p.project}
+            {p.accountIds && ` (${getAccountNamesByIds(p.accountIds)})`}
+          </span>
+        </span>
+      ))}
+    </div>
+  );
+};
+
+export default MeetingProjectRecommender;

--- a/components/meetings/meeting.tsx
+++ b/components/meetings/meeting.tsx
@@ -36,6 +36,7 @@ const MeetingRecord: FC<MeetingRecordProps> = ({
   const [meetingContext, setMeetingContext] = useState(meeting?.context);
   const {
     createMeetingActivity,
+    removeMeetingParticipant,
     updateMeetingContext,
     updateMeeting,
     createMeetingParticipant,
@@ -151,6 +152,7 @@ const MeetingRecord: FC<MeetingRecordProps> = ({
             <MeetingParticipants
               participantIds={meeting.participantIds}
               addParticipant={!addParticipants ? undefined : addParticipant}
+              removeParticipant={removeMeetingParticipant}
             />
 
             <MeetingNextActions meeting={meeting} />

--- a/components/meetings/meeting.tsx
+++ b/components/meetings/meeting.tsx
@@ -16,6 +16,7 @@ import { Accordion } from "../ui/accordion";
 import MeetingActivityList from "./meeting-activity-list";
 import MeetingNextActions from "./meeting-next-actions";
 import MeetingParticipants from "./meeting-participants";
+import MeetingProjectRecommender from "./meeting-project-recommender";
 
 type MeetingRecordProps = {
   meeting?: Meeting;
@@ -113,6 +114,13 @@ const MeetingRecord: FC<MeetingRecordProps> = ({
           allowCreateProjects
           placeholder="Add a project…"
           disabled={!meeting}
+        />
+      )}
+
+      {addProjects && (
+        <MeetingProjectRecommender
+          meeting={meeting}
+          addProjectToMeeting={handleSelectProject}
         />
       )}
 

--- a/components/people/PeopleList.tsx
+++ b/components/people/PeopleList.tsx
@@ -9,9 +9,14 @@ import PersonDetails from "./PersonDetails";
 type PeopleListProps = {
   personIds?: string[];
   showNotes?: boolean;
+  onDelete?: (personId: string) => void;
 };
 
-const PeopleList: FC<PeopleListProps> = ({ personIds, showNotes }) => {
+const PeopleList: FC<PeopleListProps> = ({
+  personIds,
+  showNotes,
+  onDelete,
+}) => {
   const { people } = usePeople();
 
   const personName = (person?: Person) =>
@@ -32,6 +37,7 @@ const PeopleList: FC<PeopleListProps> = ({ personIds, showNotes }) => {
             filter((a: PersonAccount) => a.isCurrent),
             flatMap((a) => [a.position, a.accountName])
           )(people)}
+          onDelete={() => onDelete?.(personId)}
           link={`/people/${personId}`}
         >
           <PersonDetails personId={personId} showNotes={showNotes} />

--- a/components/ui-elements/project-notes-form/project-notes-form.tsx
+++ b/components/ui-elements/project-notes-form/project-notes-form.tsx
@@ -64,30 +64,16 @@ const ProjectNotesForm: FC<ProjectNotesFormProps> = ({
         <DeleteWarning
           open={openDeleteActivityConfirmation}
           onOpenChange={setOpenDeleteActivityConfirmation}
-          confirmText={
-            <>
-              <p>
-                Are you sure you want to delete the activity with the following
-                information?
-              </p>
-              {activity?.projectIds.map((id) => (
-                <p key={id}>
-                  <small>Project: {getProjectById(id)?.project}</small>
-                </p>
-              ))}
-              {activity && (
-                <p>
-                  <small>
-                    Notes:{" "}
-                    {getTextFromEditorJsonContent(activity?.notes).slice(
-                      0,
-                      200
-                    )}
-                  </small>
-                </p>
-              )}
-            </>
-          }
+          confirmText={`Are you sure you want to delete the activity with the following information? ${activity?.projectIds.map(
+            (id) =>
+              `Project: ${getProjectById(id)?.project}${
+                activity &&
+                `; Notes: ${getTextFromEditorJsonContent(activity?.notes).slice(
+                  0,
+                  200
+                )}`
+              }`
+          )}`}
           onConfirm={deleteActivity}
         />
       )}

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,8 +1,12 @@
-# Fehlerbehebungen CRM Projekte und Hauptmenü (Version :VERSION)
+# Notizen in Blöcke aufteilen (Version :VERSION)
 
-- Es gab CRM Projekte, bei denen das Abschlussdatum weit in der Zukunft lag und das CRM Projekt bereits geschlossen ist (verloren oder gewonnen). In diesem Fall wäre das Projekt noch sehr lange und immer wieder in der Liste aufgetaucht, obwohl nichts mehr dafür getan werden konnte. Das ist nun behoben. Es wird immer das kleinere Datum für den Import herangezogen, entweder das Abschlussdatum oder das System-Abschlussdatum, das anzeigt, wann das Projekt geschlossen wurde.
-- Das Hauptmenü führte häufig zu Abstürzen, wenn der Suchbegriff einmal mehr als 3 Zeichen hatte und dann wieder weniger. Der Grund dafür war, dass die Gruppen als Komponenten immer erst dann erschienen, wenn die Suche mehr als 3 Zeichen hatte. CmdK kann nicht gut damit umgehen, wenn die React Komponente plötzlich wieder ganz verschwindet. Wir verstecken sie nun mit einer CSS Klasse, entfernen sie aber nicht komplett vom DOM.
+- In Meetings werden Projekte angezeigt, bei denen die Teilnehmer schon einmal in Meetings involviert gewesen sind. Wenn ein Projekt angeklickt wird, wird es direkt dem Meeting hinzugefügt und man kann anfangen, Notizen zu machen.
 
 ## In Arbeit
 
+- In Meetings können Teilnehmer wieder entfernt werden, wenn man sie versehentlich hinzugefügt hat.
+
+## Geplant
+
+- In der Detailansicht einer Person werden im Untertitel von Notizen die Projekte angezeigt, in die die Person involviert ist. Hier sicher stellen, dass abgeschlossene Projekte nicht aufgelistet werden.
 - Blöcke als einzelne Records in der Datenbank speichern.

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -2,10 +2,9 @@
 
 - In Meetings werden Projekte angezeigt, bei denen die Teilnehmer schon einmal in Meetings involviert gewesen sind. Wenn ein Projekt angeklickt wird, wird es direkt dem Meeting hinzugefügt und man kann anfangen, Notizen zu machen.
 - In Meetings können Teilnehmer wieder entfernt werden, wenn man sie versehentlich hinzugefügt hat.
+- In der Detailansicht einer Person werden im Untertitel von Notizen nur noch Projekte angezeigt, in die die Person involviert ist, die aber noch nicht abgeschlossen sind.
 
 ## In Arbeit
-
-- In der Detailansicht einer Person werden im Untertitel von Notizen die Projekte angezeigt, in die die Person involviert ist. Hier sicher stellen, dass abgeschlossene Projekte nicht aufgelistet werden.
 
 ## Geplant
 

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,12 +1,12 @@
-# Notizen in Blöcke aufteilen (Version :VERSION)
+# Meetings weiter optimieren (Version :VERSION)
 
 - In Meetings werden Projekte angezeigt, bei denen die Teilnehmer schon einmal in Meetings involviert gewesen sind. Wenn ein Projekt angeklickt wird, wird es direkt dem Meeting hinzugefügt und man kann anfangen, Notizen zu machen.
+- In Meetings können Teilnehmer wieder entfernt werden, wenn man sie versehentlich hinzugefügt hat.
 
 ## In Arbeit
 
-- In Meetings können Teilnehmer wieder entfernt werden, wenn man sie versehentlich hinzugefügt hat.
+- In der Detailansicht einer Person werden im Untertitel von Notizen die Projekte angezeigt, in die die Person involviert ist. Hier sicher stellen, dass abgeschlossene Projekte nicht aufgelistet werden.
 
 ## Geplant
 
-- In der Detailansicht einer Person werden im Untertitel von Notizen die Projekte angezeigt, in die die Person involviert ist. Hier sicher stellen, dass abgeschlossene Projekte nicht aufgelistet werden.
 - Blöcke als einzelne Records in der Datenbank speichern.


### PR DESCRIPTION
- In Meetings werden Projekte angezeigt, bei denen die Teilnehmer schon einmal in Meetings involviert gewesen sind. Wenn ein Projekt angeklickt wird, wird es direkt dem Meeting hinzugefügt und man kann anfangen, Notizen zu machen.
- In Meetings können Teilnehmer wieder entfernt werden, wenn man sie versehentlich hinzugefügt hat.
- In der Detailansicht einer Person werden im Untertitel von Notizen nur noch Projekte angezeigt, in die die Person involviert ist, die aber noch nicht abgeschlossen sind.
