### PR TITLE
Meetings weiter optimieren

### DIFF
--- a/components/meetings/meeting-activity-list.tsx
+++ b/components/meetings/meeting-activity-list.tsx
@@ -1,5 +1,7 @@
 import { useProjectsContext } from "@/api/ContextProjects";
 import { Meeting } from "@/api/useMeetings";
+import { getTextFromEditorJsonContent } from "@/helpers/ui-notes-writer";
+import { flow, join, map } from "lodash/fp";
 import { FC } from "react";
 import ActivityComponent from "../activities/activity";
 import TaskBadge from "../task/TaskBadge";
@@ -21,14 +23,17 @@ const MeetingActivityList: FC<MeetingActivityListProps> = ({ meeting }) => {
       <DefaultAccordionItem
         value={a.id}
         key={a.id}
-        triggerTitle="Meeting notes"
+        triggerTitle={getProjectNamesByIds(a.projectIds)}
         badge={
           <TaskBadge
             hasOpenTasks={a.hasOpenTasks}
             hasClosedTasks={!!a.closedTasks?.length}
           />
         }
-        triggerSubTitle={`Projects: ${getProjectNamesByIds(a.projectIds)}`}
+        triggerSubTitle={`Next actions: ${flow(
+          map(getTextFromEditorJsonContent),
+          join(", ")
+        )(a.openTasks)}`}
       >
         <ActivityComponent
           activityId={a.id}

--- a/components/meetings/meeting.tsx
+++ b/components/meetings/meeting.tsx
@@ -14,7 +14,6 @@ import PeopleSelector from "../ui-elements/selectors/people-selector";
 import ProjectSelector from "../ui-elements/selectors/project-selector";
 import { Accordion } from "../ui/accordion";
 import MeetingActivityList from "./meeting-activity-list";
-import MeetingNextActions from "./meeting-next-actions";
 import MeetingParticipants from "./meeting-participants";
 import MeetingProjectRecommender from "./meeting-project-recommender";
 
@@ -154,8 +153,6 @@ const MeetingRecord: FC<MeetingRecordProps> = ({
               addParticipant={!addParticipants ? undefined : addParticipant}
               removeParticipant={removeMeetingParticipant}
             />
-
-            <MeetingNextActions meeting={meeting} />
 
             <MeetingActivityList meeting={meeting} />
           </>

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,8 +1,6 @@
 # Meetings weiter optimieren (Version :VERSION)
 
-- In Meetings werden Projekte angezeigt, bei denen die Teilnehmer schon einmal in Meetings involviert gewesen sind. Wenn ein Projekt angeklickt wird, wird es direkt dem Meeting hinzugefügt und man kann anfangen, Notizen zu machen.
-- In Meetings können Teilnehmer wieder entfernt werden, wenn man sie versehentlich hinzugefügt hat.
-- In der Detailansicht einer Person werden im Untertitel von Notizen nur noch Projekte angezeigt, in die die Person involviert ist, die aber noch nicht abgeschlossen sind.
+- Statt "Meeting notes" steht nun das konkrete Projekt im Kopf des Accordions und die vereinbarten nächsten Schritte im Untertitel.
 
 ## In Arbeit
 


### PR DESCRIPTION
- Statt "Meeting notes" steht nun das konkrete Projekt im Kopf des Accordions und die vereinbarten nächsten Schritte im Untertitel.
