### PR TITLE
Verbesserungen bei der Darstellung von Meetings

### DIFF
--- a/api/useActivity.ts
+++ b/api/useActivity.ts
@@ -34,6 +34,8 @@ export type Activity = {
   projectActivityIds: string[];
   noteBlockIds: (string | null)[] | null;
   oldFormatVersion: boolean;
+  hasOpenTodos: boolean;
+  hasClosedTodos: boolean;
 };
 
 const selectionSet = [
@@ -77,6 +79,8 @@ export const mapActivity = (a: ActivityData): Activity => ({
   projectIds: a.forProjects.map(({ projectsId }) => projectsId),
   projectActivityIds: a.forProjects.map(({ id }) => id),
   oldFormatVersion: !a.formatVersion || a.formatVersion < 3,
+  hasOpenTodos: a.noteBlocks.some((b) => b.todo?.status === "OPEN"),
+  hasClosedTodos: a.noteBlocks.some((b) => b.todo?.status === "DONE"),
 });
 
 const fetchActivity =

--- a/components/meetings/MeetingAccordionItem.tsx
+++ b/components/meetings/MeetingAccordionItem.tsx
@@ -1,9 +1,9 @@
 import { useProjectsContext } from "@/api/ContextProjects";
 import { Activity } from "@/api/useActivity";
 import { Meeting } from "@/api/useMeetings";
-import useMeetingTodos from "@/api/useMeetingTodos";
 import usePeople from "@/api/usePeople";
 import { format } from "date-fns";
+import { some } from "lodash";
 import { flatMap, flow, map } from "lodash/fp";
 import { FC } from "react";
 import ActivityFormatBadge from "../activities/activity-format-badge";
@@ -19,7 +19,6 @@ type MeetingAccordionItemProps = {
 const MeetingAccordionItem: FC<MeetingAccordionItemProps> = ({ meeting }) => {
   const { getNamesByIds } = usePeople();
   const { getProjectNamesByIds } = useProjectsContext();
-  const { meetingTodos } = useMeetingTodos(meeting.id);
 
   return (
     <DefaultAccordionItem
@@ -30,8 +29,8 @@ const MeetingAccordionItem: FC<MeetingAccordionItemProps> = ({ meeting }) => {
       badge={
         <>
           <TaskBadge
-            hasOpenTasks={meetingTodos?.some((t) => !t.done)}
-            hasClosedTasks={meetingTodos?.every((t) => t.done)}
+            hasOpenTasks={some(meeting.activities, "hasOpenTodos")}
+            hasClosedTasks={some(meeting.activities, "hasClosedTodos")}
           />
           {meeting.hasOldVersionFormattedActivities && <ActivityFormatBadge />}
         </>

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,12 +1,19 @@
-# Meetings filtern nach offenen Aufgaben oder alten Notiz-Versionen (Version :VERSION)
+# Verbesserungen bei der Darstellung von Meetings (Version :VERSION)
 
-- Filter Funktion bei Meetings eingebaut, so dass nach offenen Aufgaben gefiltert werden kann oder nach Meetings, die noch das alte Notizen-Format haben.
+- Es war sehr irritierend, wenn man in einem Meeting eines der Projekte aufgeklappt hat und dann der Projektname ein weiteres Mal erschien. Nun zählen wir die Themen auf und im Untertitel werden dann die Projekte genannt. Wenn man das Topic dann aufklappt, werden die Projektnamen angezeigt und Akkordions, die die Ansicht weiterer Details ermöglichen.
 
 ## In Arbeit
 
 ## Geplant
 
+- Ich möchte Kontaktdetails in die Zwischenablage kopieren können.
+- Ich möchte einfach nur ein Kontaktdetail in das Formular kopieren und das Formular entscheidet automatisch anhand des Inhalts und anhand des Kontexts, um welche Information es sich wahrscheinlich handelt. Wenn die Information eindeutig ist, wird der Inhalt direkt gespeichert und das Formular direkt geschlossen.
 - Weitere persönliche Jahrestage abbilden (Tauftag, Taufentscheidung etc.).
 - In Wochenplanung persönliche Termine mit berücksichtigen (Geburtstage, Jahrestage).
 - Die Verarbeitung in der Inbox soll auch ermöglichen Gelerntes zu Personen abzulegen.
 - Teilnehmer und Notizen in Zwischenablage kopieren, um schneller ins Quip oder Slack zu kopieren oder eine Email zu verfassen.
+
+## Fehler
+
+- Wenn eine Kontakt mehrere Einträge in seiner Arbeitshistorie bei der gleichen Firma hat, taucht er bei der Firma mehrmals als Kontakt auf.
+- Der Cost Explorer Link ist fehlerhaft.


### PR DESCRIPTION
- Es war sehr irritierend, wenn man in einem Meeting eines der Projekte aufgeklappt hat und dann der Projektname ein weiteres Mal erschien. Nun zählen wir die Themen auf und im Untertitel werden dann die Projekte genannt. Wenn man das Topic dann aufklappt, werden die Projektnamen angezeigt und Akkordions, die die Ansicht weiterer Details ermöglichen.
