### PR TITLE
Kleine Optimierungen in Visualisierung für Meetings und Kontakte

### DIFF
--- a/api/useActivity.ts
+++ b/api/useActivity.ts
@@ -24,6 +24,11 @@ export type TempIdMapping = {
   id: string;
 };
 
+export type ProjectLinkData = {
+  id: string;
+  projectsId: string;
+};
+
 export type Activity = {
   id: string;
   notes: JSONContent;
@@ -32,6 +37,7 @@ export type Activity = {
   updatedAt: Date;
   projectIds: string[];
   projectActivityIds: string[];
+  projects: ProjectLinkData[];
   noteBlockIds: (string | null)[] | null;
   oldFormatVersion: boolean;
   hasOpenTodos: boolean;
@@ -57,6 +63,8 @@ const selectionSet = [
   "noteBlocks.todo.todo",
   "noteBlocks.todo.status",
   "noteBlocks.todo.doneOn",
+  "noteBlocks.todo.projects.id",
+  "noteBlocks.todo.projects.projectIdTodoStatus",
   "noteBlocks.people.id",
   "noteBlocks.people.personId",
 ] as const;
@@ -78,6 +86,7 @@ export const mapActivity = (a: ActivityData): Activity => ({
   updatedAt: new Date(a.updatedAt),
   projectIds: a.forProjects.map(({ projectsId }) => projectsId),
   projectActivityIds: a.forProjects.map(({ id }) => id),
+  projects: a.forProjects,
   oldFormatVersion: !a.formatVersion || a.formatVersion < 3,
   hasOpenTodos: a.noteBlocks.some((b) => b.todo?.status === "OPEN"),
   hasClosedTodos: a.noteBlocks.some((b) => b.todo?.status === "DONE"),
@@ -195,6 +204,7 @@ const useActivity = (activityId?: string) => {
       await createAndDeleteProjectTodos(editor, activity);
 
       const content = editor.getJSON();
+
       mutateActivity(
         {
           ...activity,

--- a/api/useInboxWorkflow.ts
+++ b/api/useInboxWorkflow.ts
@@ -151,7 +151,7 @@ const useInboxWorkflow = (mutate: HandleMutationFn) => {
   ) => {
     const noteBlockIds = compact(blockIds);
     if (noteBlockIds.length === 0) return;
-    const { data, errors } = await client.models.Activity.update({
+    const { errors } = await client.models.Activity.update({
       id: activityId,
       noteBlockIds,
     });
@@ -162,7 +162,7 @@ const useInboxWorkflow = (mutate: HandleMutationFn) => {
     activityId: string,
     projectId: string
   ) => {
-    const { data, errors } = await client.models.ProjectActivity.create({
+    const { errors } = await client.models.ProjectActivity.create({
       activityId,
       projectsId: projectId,
     });
@@ -183,7 +183,7 @@ const useInboxWorkflow = (mutate: HandleMutationFn) => {
   };
 
   const createNoteBlockPerson = async (blockId: string, personId: string) => {
-    const { data, errors } = await client.models.NoteBlockPerson.create({
+    const { errors } = await client.models.NoteBlockPerson.create({
       noteBlockId: blockId,
       personId,
     });

--- a/api/useMeetings.ts
+++ b/api/useMeetings.ts
@@ -55,6 +55,8 @@ export const meetingSelectionSet = [
   "activities.noteBlocks.todo.todo",
   "activities.noteBlocks.todo.status",
   "activities.noteBlocks.todo.doneOn",
+  "activities.noteBlocks.todo.projects.id",
+  "activities.noteBlocks.todo.projects.projectIdTodoStatus",
   "activities.noteBlocks.people.id",
   "activities.noteBlocks.people.personId",
 ] as const;
@@ -82,7 +84,7 @@ export const mapMeeting: (data: MeetingData) => Meeting = ({
   participantIds: participants.map(({ personId }) => personId),
   activities: flow(
     map(mapActivity),
-    sortBy((a) => -a.finishedOn.getTime())
+    sortBy((a) => a.finishedOn.getTime())
   )(activities),
   hasOldVersionFormattedActivities: activities.some(
     (a) => !a.formatVersion || a.formatVersion < 3

--- a/components/meetings/meeting-activity-list.tsx
+++ b/components/meetings/meeting-activity-list.tsx
@@ -2,7 +2,7 @@ import { useAccountsContext } from "@/api/ContextAccounts";
 import { Project, useProjectsContext } from "@/api/ContextProjects";
 import { Meeting } from "@/api/useMeetings";
 import useMeetingTodos from "@/api/useMeetingTodos";
-import { filter, flow, map } from "lodash/fp";
+import { filter, flow, identity, map } from "lodash/fp";
 import { FC } from "react";
 import ActivityComponent from "../activities/activity";
 import ActivityFormatBadge from "../activities/activity-format-badge";
@@ -40,7 +40,7 @@ const MeetingActivityList: FC<MeetingActivityListProps> = ({ meeting }) => {
         triggerTitle={`Topic ${idx + 1}`}
         triggerSubTitle={[
           ...flow(
-            (input: Project[] | undefined) => input,
+            identity<Project[] | undefined>,
             filter((p) => a.projectIds.includes(p.id)),
             map(
               (p) =>

--- a/components/people/PersonAccounts.tsx
+++ b/components/people/PersonAccounts.tsx
@@ -45,7 +45,7 @@ const PersonAccounts: FC<PersonAccountsProps> = ({
         ])
       )(person.accounts)}
     >
-      <div className="space-y-4 px-1 md:px-2">
+      <div className="space-y-4">
         <PersonAccountForm personName={person.name} onCreate={onCreate} />
 
         {person.accounts.map((pa) => (

--- a/components/people/PersonContactDetails.tsx
+++ b/components/people/PersonContactDetails.tsx
@@ -46,7 +46,7 @@ const PersonContactDetails: FC<PersonContactDetailsProps> = ({
       triggerTitle="Contact details"
       triggerSubTitle={person.details.map(buildLabel)}
     >
-      <div className="space-y-4 px-1 md:px-2">
+      <div className="space-y-4">
         <PersonContactDetailsForm
           personName={person.name}
           onCreate={onCreate}

--- a/components/people/PersonDates.tsx
+++ b/components/people/PersonDates.tsx
@@ -56,7 +56,7 @@ const PersonDates: FC<PersonDatesProps> = ({ person, updateDateFn }) =>
           `Date of death: ${format(person.dateOfDeath, "PPP")}`,
       ]}
     >
-      <div className="space-y-4 px-1 md:px-2">
+      <div className="space-y-4">
         <PersonDateHelper
           label="Date of Birth"
           value={person.dateOfBirth}

--- a/components/people/PersonLearnings.tsx
+++ b/components/people/PersonLearnings.tsx
@@ -74,7 +74,7 @@ const PersonLearnings: FC<PersonLearningsProps> = ({ personId }) => {
         )(learnings)
       }
     >
-      <div className="space-y-4 px-1 md:px-2">
+      <div className="space-y-4">
         <Button size="sm" className="gap-1" onClick={handleCreate}>
           <PlusCircle className="w-4 h-4" />
           Learning

--- a/components/people/PersonRelationships.tsx
+++ b/components/people/PersonRelationships.tsx
@@ -49,6 +49,22 @@ type PersonRelationshipsProps = {
   deleteRelationship: (id: string) => Promise<string | undefined>;
 };
 
+const validRelations = ({
+  nameOfRelationship,
+  relatedPerson,
+  endDate,
+}: PersonRelationship) =>
+  !!nameOfRelationship && !!relatedPerson?.name && !endDate;
+
+const relationText = ({
+  nameOfRelationship,
+  relatedPerson,
+  anniversary,
+}: PersonRelationship) =>
+  `${capitalize(nameOfRelationship)}: ${relatedPerson?.name}${
+    !anniversary ? "" : ` (${differenceInYears(new Date(), anniversary)}y)`
+  }`;
+
 const PersonRelationships: FC<PersonRelationshipsProps> = ({
   ownPersonId,
   relationships,
@@ -65,20 +81,9 @@ const PersonRelationships: FC<PersonRelationshipsProps> = ({
     <DefaultAccordionItem
       value="relationships"
       triggerTitle="Relations"
-      triggerSubTitle={relationships
-        .filter(
-          (r) => !!r.nameOfRelationship && !!r.relatedPerson?.name && !r.endDate
-        )
-        .map(
-          (r) =>
-            `${capitalize(r.nameOfRelationship)}: ${r.relatedPerson?.name}${
-              !r.anniversary
-                ? ""
-                : ` (${differenceInYears(new Date(), r.anniversary)}y)`
-            }`
-        )}
+      triggerSubTitle={relationships.filter(validRelations).map(relationText)}
     >
-      <div className="space-y-4 px-1 md:px-2">
+      <div className="space-y-4">
         <Button
           size="sm"
           className="gap-1"

--- a/components/people/relations/sub-relation-text.tsx
+++ b/components/people/relations/sub-relation-text.tsx
@@ -2,7 +2,16 @@ import { PersonRelationship } from "@/helpers/person/relationships";
 import { getRelationValue, notSelf } from "@/helpers/person/sub-relationships";
 import { differenceInYears, format } from "date-fns";
 import { capitalize } from "lodash";
-import { compact, filter, flatMap, flow, map, sortBy, uniqBy } from "lodash/fp";
+import {
+  compact,
+  filter,
+  flatMap,
+  flow,
+  identity,
+  map,
+  sortBy,
+  uniqBy,
+} from "lodash/fp";
 import Link from "next/link";
 import { FC } from "react";
 
@@ -20,7 +29,7 @@ const SubRelationships: FC<SubRelationshipsProps> = ({
   updateRelationship,
 }) => {
   return flow(
-    (input: PersonRelationship[]) => input,
+    identity<PersonRelationship[]>,
     flatMap("subRelations"),
     compact,
     uniqBy("personId"),

--- a/components/ui-elements/accordion/DefaultAccordionItem.tsx
+++ b/components/ui-elements/accordion/DefaultAccordionItem.tsx
@@ -89,7 +89,7 @@ const DefaultAccordionItem = forwardRef<
                 )(triggerSubTitle)}
           </AccordionTriggerSubTitle>
         </AccordionTrigger>
-        <AccordionContent className="my-2 bg-[--context-color-bg]">
+        <AccordionContent className="my-2 bg-[--context-color-bg] mx-1 md:mx-2">
           {children}
         </AccordionContent>
       </AccordionItem>

--- a/components/ui-elements/accordion/DefaultAccordionItem.tsx
+++ b/components/ui-elements/accordion/DefaultAccordionItem.tsx
@@ -89,7 +89,7 @@ const DefaultAccordionItem = forwardRef<
                 )(triggerSubTitle)}
           </AccordionTriggerSubTitle>
         </AccordionTrigger>
-        <AccordionContent className="my-2 bg-[--context-color-bg] mx-1 md:mx-2">
+        <AccordionContent className="my-2 bg-[--context-color-bg] px-1 md:px-2">
           {children}
         </AccordionContent>
       </AccordionItem>

--- a/components/ui-elements/editors/extensions/tasks/task-item.ts
+++ b/components/ui-elements/editors/extensions/tasks/task-item.ts
@@ -70,7 +70,6 @@ export const TaskItem = Node.create<TaskItemOptions>({
         keepOnSplit: false,
         parseHTML: (element) => {
           const dataChecked = element.getAttribute("data-checked");
-
           return dataChecked == null || dataChecked === "true";
         },
         renderHTML: (attributes) => ({
@@ -91,6 +90,9 @@ export const TaskItem = Node.create<TaskItemOptions>({
           "data-todo-id": attrs.todoId ?? null,
         }),
       },
+      projects: {
+        default: [],
+      },
     };
   },
 
@@ -108,6 +110,8 @@ export const TaskItem = Node.create<TaskItemOptions>({
       "li",
       mergeAttributes(this.options.HTMLAttributes, HTMLAttributes, {
         "data-type": this.name,
+        "data-block-id": node.attrs.blockId,
+        "data-todo-id": node.attrs.todoId,
       }),
       [
         "label",

--- a/components/ui-elements/editors/notes-editor/useExtensions.ts
+++ b/components/ui-elements/editors/notes-editor/useExtensions.ts
@@ -52,14 +52,6 @@ const useExtensions = (): EditorOptions["extensions"] => {
           return {
             projects: {
               default: [],
-              parseHTML: (element) => {
-                const projects = element.getAttribute("data-projects");
-                if (projects === null) return null;
-                return JSON.parse(projects);
-              },
-              renderHTML: (attrs) => ({
-                "data-projects": JSON.stringify(attrs.projects),
-              }),
             },
           };
         },

--- a/components/ui-elements/editors/todo-editor/TodoEditor.tsx
+++ b/components/ui-elements/editors/todo-editor/TodoEditor.tsx
@@ -4,13 +4,37 @@ import { EditorContent, useEditor } from "@tiptap/react";
 import { FC, useEffect } from "react";
 import useExtensions from "./useExtensions";
 
+const getParagraphWithLinkToActivity = (activityId: string): JSONContent => ({
+  type: "paragraph",
+  content: [
+    {
+      type: "text",
+      marks: [
+        { type: "italic" },
+        {
+          type: "link",
+          attrs: {
+            rel: "noopener noreferrer nofollow",
+            href: `/activities/${activityId}`,
+          },
+        },
+      ],
+      text: "Details",
+    },
+  ],
+});
+
 const getTodoEditorContent = (todos: Todo[]): JSONContent => ({
   type: "doc",
   content: [
     {
       type: "taskList",
-      content: todos.map(({ todo, todoId, blockId }) => ({
+      content: todos.map(({ todo, todoId, blockId, activityId }) => ({
         ...todo,
+        content: [
+          ...(todo.content ?? []),
+          getParagraphWithLinkToActivity(activityId),
+        ],
         attrs: {
           ...todo.attrs,
           blockId,

--- a/components/ui-elements/project-details/project-dates.tsx
+++ b/components/ui-elements/project-details/project-dates.tsx
@@ -45,7 +45,7 @@ const ProjectDates: FC<ProjectDatesProps> = ({
       onHoldTill && `On hold till: ${format(onHoldTill, "PPP")}`,
     ]}
   >
-    <div className="space-y-4 px-1 md:px-2">
+    <div className="space-y-4">
       <ProjectDatesHelper
         title="Due on"
         date={dueOn}

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -2,10 +2,9 @@
 
 - Akkordion-Inhalte sahen immer etwas komisch aus, da sie weniger eingerückt waren, als der Kopf des Akkordions.
 - Bei Next Actions in Meeting und Projekten Link zur Aktivität anbieten, um schnell dorthin springen zu können und mehr Kontext zu erhalten.
+- Todos tauchten manchmal in der Tagesplanung nicht auf. Das lag daran, dass Projekte nicht korrekt verlinkt worden sind.
 
 ## In Arbeit
-
-- Todos tauchen manchmal in der Tagesplanung nicht auf.
 
 ## Geplant
 

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,8 +1,11 @@
 # Kleine Optimierungen in Visualisierung für Meetings und Kontakte (Version :VERSION)
 
 - Akkordion-Inhalte sahen immer etwas komisch aus, da sie weniger eingerückt waren, als der Kopf des Akkordions.
+- Bei Next Actions in Meeting und Projekten Link zur Aktivität anbieten, um schnell dorthin springen zu können und mehr Kontext zu erhalten.
 
 ## In Arbeit
+
+- Todos tauchen manchmal in der Tagesplanung nicht auf.
 
 ## Geplant
 
@@ -12,10 +15,12 @@
 - In Wochenplanung persönliche Termine mit berücksichtigen (Geburtstage, Jahrestage).
 - Die Verarbeitung in der Inbox soll auch ermöglichen Gelerntes zu Personen abzulegen.
 - Teilnehmer und Notizen in Zwischenablage kopieren, um schneller ins Quip oder Slack zu kopieren oder eine Email zu verfassen.
-- Bei Next Actions in Meeting und Projekten Link anbieten, um schnell dorthin springen zu können und die gesamte Aktivität zu sehen.
+- Eine "Lean-Ansicht" wäre toll, zum Beispiel, wenn ich Notizen zu einem Projekt sehen möchte, dann scrolle ich einfach durch die Notizen ohne erst Akkordions aufklappen zu müssen.
 
 ## Fehler
 
 - Wenn eine Kontakt mehrere Einträge in seiner Arbeitshistorie bei der gleichen Firma hat, taucht er bei der Firma mehrmals als Kontakt auf.
 - Der Cost Explorer Link ist fehlerhaft.
 - Mir scheint, dass Links in Notizen nicht sauber gespeichert werden.
+- Notizen zeigen hier und da immer noch den Status, dass sie nicht im Einklang mit der Datenbank sind.
+- Wenn kein Account an einem Projekt oder einer Person hängt, tauchen manchmal leere Klammern auf.

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,6 +1,6 @@
-# Verbesserungen bei der Darstellung von Meetings (Version :VERSION)
+# Kleine Optimierungen in Visualisierung für Meetings und Kontakte (Version :VERSION)
 
-- Es war sehr irritierend, wenn man in einem Meeting eines der Projekte aufgeklappt hat und dann der Projektname ein weiteres Mal erschien. Nun zählen wir die Themen auf und im Untertitel werden dann die Projekte genannt. Wenn man das Topic dann aufklappt, werden die Projektnamen angezeigt und Akkordions, die die Ansicht weiterer Details ermöglichen.
+- Akkordion-Inhalte sahen immer etwas komisch aus, da sie weniger eingerückt waren, als der Kopf des Akkordions.
 
 ## In Arbeit
 
@@ -12,8 +12,10 @@
 - In Wochenplanung persönliche Termine mit berücksichtigen (Geburtstage, Jahrestage).
 - Die Verarbeitung in der Inbox soll auch ermöglichen Gelerntes zu Personen abzulegen.
 - Teilnehmer und Notizen in Zwischenablage kopieren, um schneller ins Quip oder Slack zu kopieren oder eine Email zu verfassen.
+- Bei Next Actions in Meeting und Projekten Link anbieten, um schnell dorthin springen zu können und die gesamte Aktivität zu sehen.
 
 ## Fehler
 
 - Wenn eine Kontakt mehrere Einträge in seiner Arbeitshistorie bei der gleichen Firma hat, taucht er bei der Firma mehrmals als Kontakt auf.
 - Der Cost Explorer Link ist fehlerhaft.
+- Mir scheint, dass Links in Notizen nicht sauber gespeichert werden.

--- a/scripts/helpers/add-project-todo.js
+++ b/scripts/helpers/add-project-todo.js
@@ -1,0 +1,175 @@
+const {
+  UpdateItemCommand,
+  DynamoDBClient,
+  QueryCommand,
+  DeleteItemCommand,
+  PutItemCommand,
+} = require("@aws-sdk/client-dynamodb");
+const { getTable, getEnvironment } = require("../import-data/environments");
+const { getAwsProfile } = require("./get-aws-profile");
+const { stdLog } = require("./filter-and-mapping");
+const { fromIni } = require("@aws-sdk/credential-providers");
+const { flow, map, uniq, slice, join, get, split, last } = require("lodash/fp");
+const { getUser } = require("./get-user");
+const uuid = require("./uuid");
+const { mapObjectToDdb, mapDdbToObject } = require("./map-ddb-object");
+
+const region = getEnvironment().region;
+const profile = getAwsProfile();
+const client = new DynamoDBClient({
+  region,
+  credentials: fromIni({ profile }),
+});
+
+const getProjectIds = async (activityId) => {
+  const TableName = getTable("ProjectActivity");
+  const projects = await client.send(
+    new QueryCommand({
+      TableName,
+      IndexName: "gsi-Activity.forProjects",
+      KeyConditionExpression: "activityId = :activityId",
+      ExpressionAttributeValues: {
+        ":activityId": { S: activityId },
+      },
+      Limit: 5000,
+    })
+  );
+  return {
+    activityId,
+    projectIds: flow(map("projectsId.S"), uniq)(projects.Items),
+  };
+};
+
+const getTodoStatus = async (todoId) => {
+  const TableName = getTable("Todo");
+  const todo = await client.send(
+    new QueryCommand({
+      TableName,
+      KeyConditionExpression: "id = :id",
+      ExpressionAttributeValues: {
+        ":id": { S: todoId },
+      },
+      Limit: 5000,
+    })
+  );
+  return flow(get(0), get("status.S"))(todo.Items);
+};
+
+const mapProjectTodo = async ({ todoId, projectIds }) => {
+  const log = stdLog(`[mapProjectTodo, todo: ${todoId}]:`);
+  const TableName = getTable("ProjectTodo");
+  const todoStatus = await getTodoStatus(todoId);
+  if (!todoStatus) {
+    log("No todo status found, skipping…");
+    return;
+  }
+  const projects = await client.send(
+    new QueryCommand({
+      TableName,
+      IndexName: "gsi-Todo.projects",
+      KeyConditionExpression: "todoId = :todoId",
+      ExpressionAttributeValues: {
+        ":todoId": { S: todoId },
+      },
+      Limit: 5000,
+    })
+  );
+  await Promise.all(
+    map(deleteProjectTodo(todoId, projectIds, todoStatus))(projects.Items)
+  );
+  await Promise.all(
+    map(createProjectTodo(todoId, projects.Items, todoStatus))(projectIds)
+  );
+};
+
+const getProjectId = flow(
+  get("projectIdTodoStatus.S"),
+  split("-"),
+  slice(0, -1),
+  join("-")
+);
+
+const getDbTodoStatus = flow(get("projectIdTodoStatus.S"), split("-"), last);
+
+const createProjectTodo =
+  (todoId, projects, todoStatus) => async (projectId) => {
+    const projectIds = map(getProjectId)(projects);
+    const log = stdLog(
+      `[createProjectTodo, todo: ${todoId}, project: ${projectId}]:`
+    );
+    if (projectIds.includes(projectId)) return;
+    log("Project doesn't exist, creating…");
+    const TableName = getTable("ProjectTodo");
+    const owner = await getUser();
+    const id = uuid();
+    const Item = mapObjectToDdb({
+      id,
+      createdAt: new Date().toISOString(),
+      owner,
+      projectIdTodoStatus: `${projectId}-${todoStatus}`,
+      todoId,
+      updatedAt: new Date().toISOString(),
+      __typename: "ProjectTodo",
+    });
+    const result = await client.send(
+      new PutItemCommand({
+        TableName,
+        Item,
+      })
+    );
+    log(
+      `Item created: (id: ${id}), status code: ${
+        result.$metadata.httpStatusCode
+      }, item: ${flow(mapDdbToObject, JSON.stringify)(Item)}`
+    );
+  };
+
+const updateProjectStatus = async (todoId, id, projectId, status) => {
+  const log = stdLog(
+    `[updateProjectStatus, todo: ${todoId}, project: ${projectId}]:`
+  );
+  const TableName = getTable("ProjectTodo");
+  const params = {
+    TableName,
+    Key: {
+      id: { S: id },
+    },
+    UpdateExpression: `SET projectIdTodoStatus = :newValue`,
+    ExpressionAttributeValues: {
+      ":newValue": { S: `${projectId}-${status}` },
+    },
+    ReturnValues: "UPDATED_NEW",
+  };
+  const response = await client.send(new UpdateItemCommand(params));
+  log("Status updated:", response.Attributes.projectIdTodoStatus.S);
+};
+
+const deleteProjectTodo =
+  (todoId, projectIds, todoStatus) => async (project) => {
+    const dbTodoStatus = getDbTodoStatus(project);
+    const projectId = getProjectId(project);
+    const log = stdLog(
+      `[deleteProjectTodo, todo: ${todoId}, project: ${projectId}]:`
+    );
+    if (projectIds.includes(projectId) && todoStatus === dbTodoStatus) return;
+    if (projectIds.includes(projectId) && todoStatus !== dbTodoStatus) {
+      log("Project exists but with wrong status…");
+      await updateProjectStatus(todoId, project.id.S, projectId, todoStatus);
+      return;
+    }
+    log("Project exists but shouldn't, deleting…");
+    const TableName = getTable("ProjectTodo");
+    const params = {
+      TableName,
+      Key: {
+        id: { S: project.id.S },
+      },
+    };
+    const response = await client.send(new DeleteItemCommand(params));
+    log("Deleted", "StatusCode", response.$metadata.httpStatusCode);
+  };
+
+module.exports = {
+  getProjectIds,
+  mapProjectTodo,
+};

--- a/scripts/start-import.js
+++ b/scripts/start-import.js
@@ -2,6 +2,7 @@ const {
   ScanCommand,
   UpdateItemCommand,
   DynamoDBClient,
+  QueryCommand,
 } = require("@aws-sdk/client-dynamodb");
 const {
   mapMeetingIdForActivity,
@@ -17,7 +18,8 @@ const {
 const { getTable, getEnvironment } = require("./import-data/environments");
 const { getAwsProfile } = require("./helpers/get-aws-profile");
 const { fromIni } = require("@aws-sdk/credential-providers");
-const { flow, compact, filter, map } = require("lodash/fp");
+const { flow, map, uniq } = require("lodash/fp");
+const { getProjectIds, mapProjectTodo } = require("./helpers/add-project-todo");
 
 const importData = async () => {
   // Account
@@ -238,6 +240,45 @@ const fillFinishedOn = async () => {
   );
 };
 
+const addProjectsToTodos = async () => {
+  const NoteBlock = getTable("NoteBlock");
+  const log = stdLog(`[addProjectsToTodos]:`);
+  log("Start processing…");
+  const region = getEnvironment().region;
+  const profile = getAwsProfile();
+  const client = new DynamoDBClient({
+    region,
+    credentials: fromIni({ profile }),
+  });
+  const noteBlocks = await client.send(
+    new QueryCommand({
+      TableName: NoteBlock,
+      IndexName: "noteBlocksByType",
+      KeyConditionExpression: "#type = :noteType",
+      ExpressionAttributeNames: {
+        "#type": "type",
+      },
+      ExpressionAttributeValues: {
+        ":noteType": { S: "taskItem" },
+      },
+      Limit: 5000,
+    })
+  );
+  const activityIds = flow(map("activityId.S"), uniq)(noteBlocks.Items);
+  const projectActivities = await Promise.all(activityIds.map(getProjectIds));
+  await Promise.all(
+    flow(
+      map(({ activityId, todoId }) => ({
+        todoId: todoId.S,
+        projectIds: projectActivities.find(
+          ({ activityId: id }) => id === activityId.S
+        ).projectIds,
+      })),
+      map(mapProjectTodo)
+    )(noteBlocks.Items)
+  );
+};
+
 /**
  * Importing data requires the files mentioned in the importData function to exist.
  * Like:
@@ -257,3 +298,4 @@ const fillFinishedOn = async () => {
 // importData();
 // logTables();
 // fillFinishedOn();
+// addProjectsToTodos();


### PR DESCRIPTION
- Akkordion-Inhalte sahen immer etwas komisch aus, da sie weniger eingerückt waren, als der Kopf des Akkordions.
- Bei Next Actions in Meeting und Projekten Link zur Aktivität anbieten, um schnell dorthin springen zu können und mehr Kontext zu erhalten.
- Todos tauchten manchmal in der Tagesplanung nicht auf. Das lag daran, dass Projekte nicht korrekt verlinkt worden sind.
