### PR TITLE
Schnelleres Erstellen von 1:1 Meetings

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -39,6 +39,7 @@ const schema = a
         context: a.ref("Context"),
         topic: a.string().required(),
         meetingOn: a.datetime(),
+        immediateTasksDone: a.boolean(),
         participants: a.hasMany("MeetingParticipant", "meetingId"),
         activities: a.hasMany("Activity", "meetingActivitiesId"),
       })

--- a/api/useMeetings.ts
+++ b/api/useMeetings.ts
@@ -231,6 +231,28 @@ const useMeetings = ({
     return data?.id;
   };
 
+  const createMeetingParticipant = async (
+    meetingId: string,
+    personId: string
+  ) => {
+    const updated: Meeting[] | undefined = meetings?.map((meeting) =>
+      meeting.id !== meetingId
+        ? meeting
+        : {
+            ...meeting,
+            participantIds: [...(meeting?.participantIds || []), personId],
+          }
+    );
+    if (updated) mutateMeetings(updated, false);
+    const { data, errors } = await client.models.MeetingParticipant.create({
+      personId,
+      meetingId: meetingId,
+    });
+    if (errors) handleApiErrors(errors, "Error adding meeting participant");
+    if (updated) mutateMeetings(updated);
+    return data?.meetingId;
+  };
+
   useEffect(() => {
     flow(map("meetingDayStr"), uniq, setMeetingDates)(meetings);
   }, [meetings]);
@@ -241,6 +263,7 @@ const useMeetings = ({
     loadingMeetings,
     meetingDates,
     createMeeting,
+    createMeetingParticipant,
   };
 };
 

--- a/components/navigation-menu/CreateOneOnOneMeeting.tsx
+++ b/components/navigation-menu/CreateOneOnOneMeeting.tsx
@@ -1,0 +1,51 @@
+import useMeetings from "@/api/useMeetings";
+import { useContextContext } from "@/contexts/ContextContext";
+import { first, flow, identity, split } from "lodash/fp";
+import { FC } from "react";
+import SearchableDataGroup from "./SearchableDataGroup";
+
+type CreateOneOnOneMeetingProps = {
+  metaPressed?: boolean;
+  items?: {
+    id: string;
+    name: string;
+    accountNames?: string;
+  }[];
+};
+
+const getFirstName = flow(identity<string>, split(" "), first);
+
+const CreateOneOnOneMeeting: FC<CreateOneOnOneMeetingProps> = ({
+  metaPressed,
+  items,
+}) => {
+  const { context } = useContextContext();
+  const { createMeeting, createMeetingParticipant } = useMeetings({ context });
+
+  const handleCreate =
+    (personId: string, personName: string, accountNames: string | undefined) =>
+    async () => {
+      const meetingName = `Meet ${getFirstName(personName)}${
+        !accountNames ? "" : `/${getFirstName(accountNames)}`
+      }`;
+      const meetingId = await createMeeting(meetingName, context);
+      if (!meetingId) return;
+      await createMeetingParticipant(meetingId, personId);
+      return meetingId;
+    };
+
+  return (
+    <SearchableDataGroup
+      heading="Start meeting…"
+      metaPressed={metaPressed}
+      items={items?.map(({ id, name, accountNames }) => ({
+        id,
+        value: `…with ${name}${!accountNames ? "" : ` (${accountNames})`}`,
+        link: "/meetings",
+        processFn: handleCreate(id, name, accountNames),
+      }))}
+    />
+  );
+};
+
+export default CreateOneOnOneMeeting;

--- a/components/navigation-menu/NavigationMenu.tsx
+++ b/components/navigation-menu/NavigationMenu.tsx
@@ -28,6 +28,7 @@ import {
 } from "../ui/command";
 import { DialogDescription, DialogTitle } from "../ui/dialog";
 import ContextSwitcher from "./ContextSwitcher";
+import CreateOneOnOneMeeting from "./CreateOneOnOneMeeting";
 import SearchableDataGroup from "./SearchableDataGroup";
 
 type UrlNavigationItem = {
@@ -238,6 +239,7 @@ const NavigationMenu = () => {
               link: `/projects/${id}`,
             }))}
         />
+        <CreateOneOnOneMeeting metaPressed={metaPressed} items={people} />
         {createItemsNavigation.map(({ label, action }, index) => (
           <CommandItem key={index} forceMount={true} onSelect={action}>
             <Plus className="mr-2 h-4 w-4" />

--- a/components/navigation-menu/SearchableDataGroup.tsx
+++ b/components/navigation-menu/SearchableDataGroup.tsx
@@ -4,6 +4,8 @@ import { useRouter } from "next/router";
 import { FC } from "react";
 import { CommandGroup, CommandItem } from "../ui/command";
 
+type ProcessFunction = () => Promise<string | undefined>;
+
 type SearchableDataGroupProps = {
   heading: string;
   metaPressed?: boolean;
@@ -11,6 +13,7 @@ type SearchableDataGroupProps = {
     id: string;
     value: string;
     link: string;
+    processFn?: ProcessFunction;
   }[];
 };
 
@@ -22,19 +25,28 @@ const SearchableDataGroup: FC<SearchableDataGroupProps> = ({
   const search = useCommandState((state) => state.search);
   const router = useRouter();
 
-  const routeToUrl = (url?: string) => () => {
+  const routeToUrl = (url?: string) => {
     if (!url) return;
     if (metaPressed) window.open(url, "_blank");
     else router.push(url);
   };
+
+  const handleSelect =
+    (url: string | undefined, processFn: ProcessFunction | undefined) =>
+    async () => {
+      if (!processFn) return routeToUrl(url);
+      const newItemId = await processFn();
+      if (!newItemId) return;
+      routeToUrl(`${url}/${newItemId}`);
+    };
 
   return (
     <CommandGroup
       heading={heading}
       className={cn((!search || search.length < 4 || !items) && "hidden")}
     >
-      {items?.map(({ id, value, link }) => (
-        <CommandItem key={id} onSelect={routeToUrl(link)}>
+      {items?.map(({ id, value, link, processFn }) => (
+        <CommandItem key={id} onSelect={handleSelect(link, processFn)}>
           {value}
         </CommandItem>
       ))}

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,10 +1,10 @@
-# Fehler in Meeting Aufgaben beheben (Version :VERSION)
+# Schnelleres Erstellen von 1:1 Meetings (Version :VERSION)
 
-- Für Meetings können nun wieder die Aufgaben angezeigt werden.
+- Meetings können nun direkt aus dem Navigationsmenü gestartet werden, mit bereits einem Teilnehmer eingerichtet. Das Meeting enthält dann den Namen des Teilnehmers (z.B. bei Horst Müller von Musterfirma würde es heißen „Meet Horst/Musterfirms“).
 
 ## In Arbeit
 
-- Es wäre richtig cool, bereits aus dem Navigationsmenü ein Meeting zu starten mit einem Teilnehmer bereits hinzugefügt. Z.B. ich suche nach "Horst Müller" und bekomme angeboten, seinen Kontakt zu öffnen oder ein Meeting mit ihm zu starten. Dann wird ein neues Meeting erstellt, Horst Müller als Teilnehmer hinzugefügt und das Meeting heißt z.B. "Sync Horst Müller".
+- Wenn ich meine, dass ich im Anschluss an ein Meeting alle möglichen Aufgaben erledigt habe, dann möchte ich das Meeting als erledigt markieren. Die restlichen Aufgaben tauchen weiterhin in den Projekten auf, aber in den Meetings tauchen wenigstens nicht mehr unerledigte Aufgaben auf, die ich im Moment gar nicht erledigen kann.
 - Inbox Items sind nicht sauber voneinander getrennt. Man weiß nicht genau wofür die Buttons sind. Für darüber oder drunter?
 - Bei den Inbox Items fehlen die Angaben, wann der Eintrag angelegt wurde.
 - Wenn die Internetverbindung gerade nicht so stabil ist und ein neues Inbox Item erstellt wird, kann es eine Weile dauern und in der Zeit ist für den Anwender nicht sichtbar, dass der Eintrag gerade gespeichert wird.


### PR DESCRIPTION
- Meetings können nun direkt aus dem Navigationsmenü gestartet werden, mit bereits einem Teilnehmer eingerichtet. Das Meeting enthält dann den Namen des Teilnehmers (z.B. bei Horst Müller von Musterfirma würde es heißen „Meet Horst/Musterfirms“).
