### PR TITLE
Projekt-Detailseite um Planung erweitern

### DIFF
--- a/components/planning/DecisionSection.tsx
+++ b/components/planning/DecisionSection.tsx
@@ -1,0 +1,63 @@
+import { Project } from "@/api/ContextProjects";
+import useWeekPlan from "@/api/useWeekPlan";
+import { cn } from "@/lib/utils";
+import { differenceInCalendarDays } from "date-fns";
+import { FC, useState } from "react";
+import { Label } from "../ui/label";
+import DecisionButton from "./DecisionButton";
+
+type DecisionSectionProps = {
+  project: Project;
+  className?: string;
+  saveOnHoldDate: (onHoldTill: Date | null) => void;
+};
+
+const DecisionSection: FC<DecisionSectionProps> = ({
+  project,
+  className,
+  saveOnHoldDate,
+}) => {
+  const { makeProjectDecision, weekPlan } = useWeekPlan();
+  const [selectedChoice, setSelectedChoice] = useState("");
+
+  const handleDecision = (inFocusThisWeek: boolean, choice: string) => () => {
+    setSelectedChoice(choice);
+    makeProjectDecision({ inFocusThisWeek, project, saveOnHoldDate });
+  };
+
+  return (
+    weekPlan && (
+      <div className={cn(className)}>
+        <Label htmlFor={`${project.id}-decision`} className="font-semibold">
+          Can you make progress on this project this week?
+        </Label>
+
+        <div id={`${project.id}-decision`} className="space-x-2">
+          <DecisionButton
+            label="Yes"
+            selected={weekPlan.projectIds.some((id) => id === project.id)}
+            makeDecision={handleDecision(true, "Yes")}
+            isLoading={selectedChoice === "Yes"}
+            disabled={selectedChoice !== ""}
+          />
+
+          <DecisionButton
+            label="No"
+            selected={
+              !!project.onHoldTill &&
+              differenceInCalendarDays(
+                project.onHoldTill,
+                weekPlan.startDate
+              ) >= 7
+            }
+            makeDecision={handleDecision(false, "No")}
+            isLoading={selectedChoice === "No"}
+            disabled={selectedChoice !== ""}
+          />
+        </div>
+      </div>
+    )
+  );
+};
+
+export default DecisionSection;

--- a/components/planning/MakeProjectDecision.tsx
+++ b/components/planning/MakeProjectDecision.tsx
@@ -1,62 +1,26 @@
 import { Project } from "@/api/ContextProjects";
-import useWeekPlan from "@/api/useWeekPlan";
-import { differenceInCalendarDays } from "date-fns";
-import { FC, useState } from "react";
+import { FC } from "react";
 import ProjectAccordionItem from "../projects/ProjectAccordionItem";
-import { Label } from "../ui/label";
-import DecisionButton from "./DecisionButton";
+import DecisionSection from "./DecisionSection";
 
 type MakeProjectDecisionProps = {
-  startDate: Date;
   project: Project;
-  isInFocus?: boolean;
   saveOnHoldDate: (onHoldTill: Date | null) => void;
 };
 
 const MakeProjectDecision: FC<MakeProjectDecisionProps> = ({
-  isInFocus,
-  startDate,
   project,
   saveOnHoldDate,
 }) => {
-  const { makeProjectDecision } = useWeekPlan();
-  const [selectedChoice, setSelectedChoice] = useState("");
-
-  const handleDecision = (inFocusThisWeek: boolean, choice: string) => () => {
-    setSelectedChoice(choice);
-    makeProjectDecision({ inFocusThisWeek, project, saveOnHoldDate });
-  };
-
   return (
     <div className="space-y-2">
       <ProjectAccordionItem project={project} />
 
-      <div className="flex flex-col space-y-2">
-        <Label htmlFor={`${project.id}-decision`} className="font-semibold">
-          Can you make progress on this project this week?
-        </Label>
-
-        <div id={`${project.id}-decision`} className="space-x-2">
-          <DecisionButton
-            label="Yes"
-            selected={!!isInFocus}
-            makeDecision={handleDecision(true, "Yes")}
-            isLoading={selectedChoice === "Yes"}
-            disabled={selectedChoice !== ""}
-          />
-
-          <DecisionButton
-            label="No"
-            selected={
-              !!project.onHoldTill &&
-              differenceInCalendarDays(project.onHoldTill, startDate) >= 7
-            }
-            makeDecision={handleDecision(false, "No")}
-            isLoading={selectedChoice === "No"}
-            disabled={selectedChoice !== ""}
-          />
-        </div>
-      </div>
+      <DecisionSection
+        project={project}
+        className="flex flex-col space-y-2"
+        saveOnHoldDate={saveOnHoldDate}
+      />
     </div>
   );
 };

--- a/components/planning/PlanWeekContextWork.tsx
+++ b/components/planning/PlanWeekContextWork.tsx
@@ -8,10 +8,8 @@ import {
   usePlanAccountProjects,
   withPlanAccountProjects,
 } from "./usePlanAccountProjects";
-import { useWeekPlanContext } from "./useWeekPlanContext";
 
 const PlanWeekContextWork = () => {
-  const { weekPlan, startDate } = useWeekPlanContext();
   const { accountsProjects, loadingAccounts, errorAccounts, saveProjectDates } =
     usePlanAccountProjects();
 
@@ -37,11 +35,7 @@ const PlanWeekContextWork = () => {
             <Accordion type="single" collapsible>
               {projects.map((project) => (
                 <MakeProjectDecision
-                  startDate={startDate}
                   key={project.id}
-                  isInFocus={weekPlan?.projectIds.some(
-                    (id) => id === project.id
-                  )}
                   project={project}
                   saveOnHoldDate={(onHoldTill) =>
                     saveProjectDates({ projectId: project.id, onHoldTill })

--- a/components/ui-elements/project-details/project-details.tsx
+++ b/components/ui-elements/project-details/project-details.tsx
@@ -1,5 +1,6 @@
 import { Project, useProjectsContext } from "@/api/ContextProjects";
 import { contexts } from "@/components/navigation-menu/ContextSwitcher";
+import DecisionSection from "@/components/planning/DecisionSection";
 import ProjectInvolvedPeople from "@/components/projects/project-involved-people";
 import { Accordion } from "@/components/ui/accordion";
 import { Context } from "@/contexts/ContextContext";
@@ -83,6 +84,14 @@ const ProjectDetails: FC<ProjectDetailsProps> = ({
             <ContextWarning recordContext={projectContext} />
           </RecordDetails>
         )}
+
+        <DecisionSection
+          project={project}
+          saveOnHoldDate={(onHoldTill) =>
+            saveProjectDates({ projectId: project.id, onHoldTill })
+          }
+          className="mx-1 md:mx-2"
+        />
 
         <Accordion type="single" collapsible>
           <ProjectAccountDetails

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,6 +1,6 @@
-# Involvierte Personen an Projekten zeigen (Version :VERSION)
+# Projekt-Detailseite um Planung erweitern (Version :VERSION)
 
-- In den Projektdetails werden nun Personen angezeigt, die in Meetings dabei gewesen sind, bei dem das Projekt behandelt wurde.
+- Wenn gerade eine wöchentliche Planung im Gange ist, wird auf der Projektdetailseite die Möglichkeit geboten, für das Projekt zu entscheiden, ob es in der aktuellen Woche behandelt werden soll.
 
 ## In Arbeit
 


### PR DESCRIPTION
- Wenn gerade eine wöchentliche Planung im Gange ist, wird auf der Projektdetailseite die Möglichkeit geboten, für das Projekt zu entscheiden, ob es in der aktuellen Woche behandelt werden soll.
