### PR TITLE
Wichtigste Kontakte anzeigen

### DIFF
--- a/api/useAccountPeople.ts
+++ b/api/useAccountPeople.ts
@@ -1,9 +1,13 @@
 import { type Schema } from "@/amplify/data/resource";
 import { generateClient, SelectionSet } from "aws-amplify/data";
-import { isFuture } from "date-fns";
-import { filter, flow, get, identity, map, max, sortBy, uniq } from "lodash/fp";
+import { filter, flow, identity, map, sortBy, uniq } from "lodash/fp";
 import useSWR from "swr";
 import { handleApiErrors } from "./globals";
+import {
+  getLatestUpdate,
+  isCurrentRole,
+  personName,
+} from "@/helpers/account-people";
 const client = generateClient<Schema>();
 
 const selectionSet = [
@@ -19,49 +23,10 @@ const selectionSet = [
   "person.learnings.createdAt",
 ] as const;
 
-type PersonAccountData = SelectionSet<
+export type PersonAccountData = SelectionSet<
   Schema["PersonAccount"]["type"],
   typeof selectionSet
 >;
-type ActivityData =
-  PersonAccountData["person"]["meetings"][number]["meeting"]["activities"][number];
-type LearningData = PersonAccountData["person"]["learnings"][number];
-
-const getLatestUpdate = (p: PersonAccountData) =>
-  -max([
-    new Date(p.person.updatedAt).getTime(),
-    flow(
-      get("person.meetings"),
-      map(
-        flow(
-          get("meeting.activities"),
-          map((a: ActivityData) =>
-            new Date(a.finishedOn || a.createdAt).getTime()
-          ),
-          max
-        )
-      ),
-      max
-    )(p),
-    flow(
-      get("person.learnings"),
-      map((l: LearningData) => new Date(l.learnedOn || l.createdAt).getTime()),
-      max
-    )(p),
-  ]);
-
-type AccountPerson = {
-  id: string;
-  name: string;
-};
-
-const personName = ({
-  person: { id, name },
-  position,
-}: PersonAccountData): AccountPerson => ({
-  id,
-  name: `${name}${!position ? "" : ` (${position})`}`,
-});
 
 const fetchPeople = (accountId?: string) => async () => {
   if (!accountId) return;
@@ -80,7 +45,7 @@ const fetchPeople = (accountId?: string) => async () => {
   try {
     return flow(
       identity<PersonAccountData[] | undefined>,
-      filter((pa) => !pa.endDate || isFuture(new Date(pa.endDate))),
+      filter(isCurrentRole),
       sortBy(getLatestUpdate),
       map(personName),
       uniq

--- a/api/useInteractions.ts
+++ b/api/useInteractions.ts
@@ -1,0 +1,82 @@
+import { type Schema } from "@/amplify/data/resource";
+import { generateClient, SelectionSet } from "aws-amplify/data";
+import { filter, flow, sortBy } from "lodash/fp";
+import useSWR from "swr";
+import { handleApiErrors } from "./globals";
+import { fetchUser } from "./useUser";
+import {
+  hasMeetings,
+  isCurrentRole,
+  PeersOrCustomersFilter,
+  reduceInteractions,
+} from "@/helpers/interactions";
+const client = generateClient<Schema>();
+
+const selectionSet = [
+  "startDate",
+  "endDate",
+  "position",
+  "account.name",
+  "person.id",
+  "person.name",
+  "person.meetings.meeting.meetingOn",
+  "person.meetings.meeting.createdAt",
+] as const;
+
+export type AccountData = SelectionSet<
+  Schema["PersonAccount"]["type"],
+  typeof selectionSet
+>;
+
+const fetchInteractions =
+  (weeks: number, peersOrCustomers: PeersOrCustomersFilter) => async () => {
+    const { currentAccountId } = await fetchUser();
+    if (!currentAccountId) return;
+    const { data, errors } =
+      peersOrCustomers === "PEERS"
+        ? await client.models.PersonAccount.listPersonAccountByAccountId(
+            {
+              accountId: currentAccountId,
+            },
+            {
+              selectionSet,
+              limit: 5000,
+            }
+          )
+        : await client.models.PersonAccount.list({
+            filter: { accountId: { ne: currentAccountId } },
+            selectionSet,
+            limit: 5000,
+          });
+    if (errors) {
+      handleApiErrors(errors, "Error loading interactions");
+      throw errors;
+    }
+    try {
+      return flow(
+        filter(isCurrentRole),
+        reduceInteractions(weeks, peersOrCustomers),
+        filter(hasMeetings),
+        sortBy(({ meetings }) => -meetings)
+      )(data);
+    } catch (error) {
+      console.error("Error in fetchInteractions", error);
+      throw error;
+    }
+  };
+
+export const useInteractions = (
+  weeks: number,
+  peersOrCustomers: PeersOrCustomersFilter
+) => {
+  const {
+    data: interactions,
+    error,
+    isLoading,
+  } = useSWR(
+    `/api/interactions/${weeks}/${peersOrCustomers}`,
+    fetchInteractions(weeks, peersOrCustomers)
+  );
+
+  return { interactions, error, isLoading };
+};

--- a/components/interactions/peers-customers-filter-btn-grp.tsx
+++ b/components/interactions/peers-customers-filter-btn-grp.tsx
@@ -1,0 +1,31 @@
+import { FC } from "react";
+import { useInteractionFilter } from "./useInteractionFilter";
+import { cn } from "@/lib/utils";
+import ButtonGroup from "../ui-elements/btn-group/btn-group";
+import {
+  PEERS_OR_CUSTOMERS,
+  PeersOrCustomersFilter,
+} from "@/helpers/interactions";
+
+type InteractionPeersOrCustomersFilterBtnGrpProps = {
+  className?: string;
+};
+
+const InteractionPeersOrCustomersFilterBtnGrp: FC<
+  InteractionPeersOrCustomersFilterBtnGrpProps
+> = ({ className }) => {
+  const { peersOrCustomers, setPeersOrCustomers } = useInteractionFilter();
+
+  return (
+    <div className={cn(className)}>
+      <div className="font-semibold">Peers or Customers:</div>
+      <ButtonGroup
+        values={PEERS_OR_CUSTOMERS as PeersOrCustomersFilter[]}
+        selectedValue={peersOrCustomers}
+        onSelect={setPeersOrCustomers}
+      />
+    </div>
+  );
+};
+
+export default InteractionPeersOrCustomersFilterBtnGrp;

--- a/components/interactions/timeframe-filter-btn-grp.tsx
+++ b/components/interactions/timeframe-filter-btn-grp.tsx
@@ -1,0 +1,31 @@
+import { FC } from "react";
+import { useInteractionFilter } from "./useInteractionFilter";
+import { cn } from "@/lib/utils";
+import ButtonGroup from "../ui-elements/btn-group/btn-group";
+import {
+  INTERACTION_TIME_FILTER,
+  InteractionTimeFilter,
+} from "@/helpers/interactions";
+
+type InteractionTimeFilterBtnGrpProps = {
+  className?: string;
+};
+
+const InteractionTimeFilterBtnGrp: FC<InteractionTimeFilterBtnGrpProps> = ({
+  className,
+}) => {
+  const { weeks, setWeeks } = useInteractionFilter();
+
+  return (
+    <div className={cn(className)}>
+      <div className="font-semibold">Weeks:</div>
+      <ButtonGroup
+        values={INTERACTION_TIME_FILTER as InteractionTimeFilter[]}
+        selectedValue={weeks}
+        onSelect={setWeeks}
+      />
+    </div>
+  );
+};
+
+export default InteractionTimeFilterBtnGrp;

--- a/components/interactions/useInteractionFilter.tsx
+++ b/components/interactions/useInteractionFilter.tsx
@@ -1,0 +1,74 @@
+import { useInteractions } from "@/api/useInteractions";
+import {
+  Interaction,
+  InteractionTimeFilter,
+  isValidPeersOrCustomersFilter,
+  isValidWeekFilter,
+  PeersOrCustomersFilter,
+} from "@/helpers/interactions";
+import { ComponentType, createContext, FC, useContext, useState } from "react";
+
+interface InteractionFilterType {
+  weeks: InteractionTimeFilter;
+  setWeeks: (weeks: string) => void;
+  peersOrCustomers: PeersOrCustomersFilter;
+  setPeersOrCustomers: (peersOrCustomers: string) => void;
+  interactions: Interaction[] | undefined;
+}
+
+const InteractionFilter = createContext<InteractionFilterType | null>(null);
+
+export const useInteractionFilter = () => {
+  const searchContext = useContext(InteractionFilter);
+  if (!searchContext)
+    throw new Error(
+      "useInteractionFilter must be used within InteractionFilterProvider"
+    );
+  return searchContext;
+};
+
+interface InteractionFilterProviderProps {
+  children: React.ReactNode;
+}
+
+export const InteractionFilterProvider: FC<InteractionFilterProviderProps> = ({
+  children,
+}) => {
+  const [weeks, setWeeks] = useState<InteractionTimeFilter>("13");
+  const [peersOrCustomers, setPeersOrCustomers] =
+    useState<PeersOrCustomersFilter>("PEERS");
+  const { interactions } = useInteractions(parseInt(weeks), peersOrCustomers);
+
+  const onWeeksChange = (weeks: string) =>
+    isValidWeekFilter(weeks) && setWeeks(weeks);
+
+  const onPeersOrCustomersChange = (peersOrCustomers: string) =>
+    isValidPeersOrCustomersFilter(peersOrCustomers) &&
+    setPeersOrCustomers(peersOrCustomers);
+
+  return (
+    <InteractionFilter.Provider
+      value={{
+        weeks,
+        setWeeks: onWeeksChange,
+        interactions,
+        peersOrCustomers,
+        setPeersOrCustomers: onPeersOrCustomersChange,
+      }}
+    >
+      {children}
+    </InteractionFilter.Provider>
+  );
+};
+
+export function withInteractionFilter<Props extends object>(
+  Component: ComponentType<Props>
+) {
+  return function WrappedProvider(componentProps: Props) {
+    return (
+      <InteractionFilterProvider>
+        <Component {...componentProps} />
+      </InteractionFilterProvider>
+    );
+  };
+}

--- a/components/navigation-menu/NavigationMenu.tsx
+++ b/components/navigation-menu/NavigationMenu.tsx
@@ -212,15 +212,17 @@ const NavigationMenu = () => {
             </CommandItem>
           ))}
         </CommandGroup>
-        <SearchableDataGroup
-          heading="Accounts"
-          metaPressed={metaPressed}
-          items={accounts?.map(({ id, name }) => ({
-            id,
-            value: name,
-            link: `/accounts/${id}`,
-          }))}
-        />
+        {isWorkContext() && (
+          <SearchableDataGroup
+            heading="Accounts"
+            metaPressed={metaPressed}
+            items={accounts?.map(({ id, name }) => ({
+              id,
+              value: name,
+              link: `/accounts/${id}`,
+            }))}
+          />
+        )}
         {isFamilyContext() && (
           <SearchableDataGroup
             heading="Bible"

--- a/components/navigation-menu/NavigationMenu.tsx
+++ b/components/navigation-menu/NavigationMenu.tsx
@@ -106,6 +106,7 @@ const NavigationMenu = () => {
           { label: "Accounts", url: "/accounts", shortcut: "^A" },
           { label: "Territories", url: "/territories" },
           { label: "CRM Projects", url: "/crm-projects" },
+          { label: "Count of Interactions", url: "/interactions" },
         ]
       : []),
     { label: "Inbox", url: "/inbox", shortcut: "^I" },

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,8 +1,12 @@
-# Meetings durchsuchen (Version :VERSION)
+# Wichtigste Kontakte anzeigen (Version :VERSION)
 
-- Ähnlich wie bei Projekten können nun die Meetings durchsucht werden.
+## Fehlerbehebungen
+
+- Accounts werden beim Suchen im Navigationsmenü nur noch im Arbeits-Kontext angezeigt.
 
 ## In Arbeit
+
+- Über den Menüpunkt „Count of Interactions“ lassen sich nun die Kontakte anzeigen, mit denen am meisten Interaktionen stattgefunden haben.
 
 ## Geplant
 

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,12 +1,12 @@
 # Wichtigste Kontakte anzeigen (Version :VERSION)
 
+- Über den Menüpunkt „Count of Interactions“ lassen sich nun die Kontakte anzeigen, mit denen am meisten Interaktionen stattgefunden haben. Das gilt sowohl für Kollegen, wie für Kunden und Partner.
+
 ## Fehlerbehebungen
 
 - Accounts werden beim Suchen im Navigationsmenü nur noch im Arbeits-Kontext angezeigt.
 
 ## In Arbeit
-
-- Über den Menüpunkt „Count of Interactions“ lassen sich nun die Kontakte anzeigen, mit denen am meisten Interaktionen stattgefunden haben.
 
 ## Geplant
 

--- a/helpers/account-people.ts
+++ b/helpers/account-people.ts
@@ -1,0 +1,47 @@
+import { PersonAccountData } from "@/api/useAccountPeople";
+import { isFuture, isPast } from "date-fns";
+import { flow, get, map, max } from "lodash/fp";
+
+type ActivityData =
+  PersonAccountData["person"]["meetings"][number]["meeting"]["activities"][number];
+type LearningData = PersonAccountData["person"]["learnings"][number];
+
+export type AccountPerson = {
+  id: string;
+  name: string;
+};
+
+export const personName = ({
+  person: { id, name },
+  position,
+}: PersonAccountData): AccountPerson => ({
+  id,
+  name: `${name}${!position ? "" : ` (${position})`}`,
+});
+
+export const isCurrentRole = ({ startDate, endDate }: PersonAccountData) =>
+  (!endDate || isFuture(new Date(endDate))) &&
+  (!startDate || isPast(new Date(startDate)));
+
+export const getLatestUpdate = (p: PersonAccountData) =>
+  -max([
+    new Date(p.person.updatedAt).getTime(),
+    flow(
+      get("person.meetings"),
+      map(
+        flow(
+          get("meeting.activities"),
+          map((a: ActivityData) =>
+            new Date(a.finishedOn || a.createdAt).getTime()
+          ),
+          max
+        )
+      ),
+      max
+    )(p),
+    flow(
+      get("person.learnings"),
+      map((l: LearningData) => new Date(l.learnedOn || l.createdAt).getTime()),
+      max
+    )(p),
+  ]);

--- a/helpers/interactions.ts
+++ b/helpers/interactions.ts
@@ -1,0 +1,104 @@
+import { AccountData } from "@/api/useInteractions";
+import { differenceInWeeks, isFuture, isPast } from "date-fns";
+import { compact, filter, flow, get, identity, map, size } from "lodash/fp";
+
+export type Interaction = {
+  personId: string;
+  positions: string;
+  name: string;
+  meetings: number;
+};
+
+export const INTERACTION_TIME_FILTER = ["4", "13", "26", "52"];
+const INTERACTION_TIME_FILTER_CONST = ["4", "13", "26", "52"] as const;
+export type InteractionTimeFilter =
+  (typeof INTERACTION_TIME_FILTER_CONST)[number];
+
+export const PEERS_OR_CUSTOMERS = ["PEERS", "CUSTOMERS"];
+const PEERS_OR_CUSTOMERS_CONST = ["PEERS", "CUSTOMERS"] as const;
+export type PeersOrCustomersFilter = (typeof PEERS_OR_CUSTOMERS_CONST)[number];
+
+export const isValidWeekFilter = (
+  weeks: string
+): weeks is InteractionTimeFilter =>
+  INTERACTION_TIME_FILTER_CONST.includes(weeks as InteractionTimeFilter);
+
+export const isValidPeersOrCustomersFilter = (
+  peersOrCustomers: string
+): peersOrCustomers is PeersOrCustomersFilter =>
+  PEERS_OR_CUSTOMERS_CONST.includes(peersOrCustomers as PeersOrCustomersFilter);
+
+export const isCurrentRole = ({ startDate, endDate }: AccountData) =>
+  (!endDate || isFuture(new Date(endDate))) &&
+  (!startDate || isPast(new Date(startDate)));
+
+const getMeetingDate = ({
+  meetingOn,
+  createdAt,
+}: AccountData["person"]["meetings"][number]["meeting"]) =>
+  new Date(meetingOn ?? createdAt);
+
+const isMeetingDateInRange = (weeks: number) => (date: Date) =>
+  differenceInWeeks(new Date(), date) <= weeks;
+
+const mapInteraction = (
+  weeks: number,
+  peersOrCustomers: PeersOrCustomersFilter,
+  { positions, meetings, ...existing }: Interaction,
+  ad: AccountData
+): Interaction =>
+  ({
+    ...existing,
+    positions: [
+      ...(!positions ? [] : [positions]),
+      ...(peersOrCustomers === "PEERS" ? [] : [ad.account?.name ?? ""]),
+      ad.position,
+    ].join(", "),
+    meetings:
+      (flow(
+        identity<AccountData>,
+        get("person.meetings"),
+        map("meeting"),
+        compact,
+        map(getMeetingDate),
+        filter(isMeetingDateInRange(weeks)),
+        size
+      )(ad) ?? 0) + meetings,
+  } as Interaction);
+
+const interactionWithoutCurrentPerson = (
+  interactions: Interaction[],
+  person: AccountData["person"]
+) => interactions.filter(({ personId }) => personId !== person.id);
+
+const currentPerson = (
+  interactions: Interaction[],
+  person: AccountData["person"]
+) =>
+  interactions.find(({ personId }) => personId === person.id) ?? {
+    personId: person.id,
+    positions: "",
+    name: person.name,
+    meetings: 0,
+  };
+
+export const reduceInteractions =
+  (weeks: number, peersOrCustomers: PeersOrCustomersFilter) =>
+  (interactions: AccountData[]) =>
+    interactions.reduce(
+      (prev, curr) =>
+        !curr.person
+          ? prev
+          : [
+              ...interactionWithoutCurrentPerson(prev, curr.person),
+              mapInteraction(
+                weeks,
+                peersOrCustomers,
+                currentPerson(prev, curr.person),
+                curr
+              ),
+            ],
+      [] as Interaction[]
+    );
+
+export const hasMeetings = ({ meetings }: Interaction) => Boolean(meetings);

--- a/pages/interactions.tsx
+++ b/pages/interactions.tsx
@@ -1,0 +1,35 @@
+import InteractionPeersOrCustomersFilterBtnGrp from "@/components/interactions/peers-customers-filter-btn-grp";
+import InteractionTimeFilterBtnGrp from "@/components/interactions/timeframe-filter-btn-grp";
+import {
+  useInteractionFilter,
+  withInteractionFilter,
+} from "@/components/interactions/useInteractionFilter";
+import MainLayout from "@/components/layouts/MainLayout";
+
+const InteractionsPage = () => {
+  const { interactions } = useInteractionFilter();
+
+  return (
+    <MainLayout sectionName="Interactions" title="Interactions">
+      <div className="space-y-6">
+        <InteractionTimeFilterBtnGrp className="bg-bgTransparent sticky top-[6.75rem] md:top-[8.25rem] z-[35] pb-1" />
+
+        <InteractionPeersOrCustomersFilterBtnGrp className="bg-bgTransparent sticky top-[11rem] md:top-[12.5rem] z-[35] pb-2 md:pb-4" />
+
+        <div>Anzahl: {interactions?.length ?? 0}</div>
+
+        <div className="space-y-2">
+          {interactions?.map(({ personId, name, positions, meetings }) => (
+            <div key={personId}>
+              <span className="font-bold">{name}</span> ({positions}) -{" "}
+              <span className="font-semibold text-blue-600">{meetings}</span>{" "}
+              Interactions
+            </div>
+          ))}
+        </div>
+      </div>
+    </MainLayout>
+  );
+};
+
+export default withInteractionFilter(InteractionsPage);


### PR DESCRIPTION
- Über den Menüpunkt „Count of Interactions“ lassen sich nun die Kontakte anzeigen, mit denen am meisten Interaktionen stattgefunden haben. Das gilt sowohl für Kollegen, wie für Kunden und Partner.

## Fehlerbehebungen

- Accounts werden beim Suchen im Navigationsmenü nur noch im Arbeits-Kontext angezeigt.
