### PR TITLE
Accounts bekommen optional einen kurzen Namen

### DIFF
--- a/amplify/data/account-schema.ts
+++ b/amplify/data/account-schema.ts
@@ -78,6 +78,8 @@ const accountSchema = {
         .authorization((allow) => [allow.owner().to(["read", "delete"])]),
       notionId: a.integer(),
       name: a.string().required(),
+      shortName: a.string(),
+      mainColor: a.string(),
       order: a.integer(),
       introduction: a.string(),
       introductionJson: a.json(),

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,4 +1,7 @@
-# Mehrere Projekte einem CRM Projekt hinzufügen (Version :VERSION)
+# Accounts bekommen optional einen kurzen Namen (Version :VERSION)
+
+- Kurzen Namen für Accounts eingeführt. So kann zum Beispiel der Name "Unternehmensgruppe Sommerfeld" mit "Sommerfeld" abgekürzt werden.
+- Einem Account kann eine primäre Farbe zugeordnet werden. Das kann hilfreich sein, für die Wiedererkennung an verschiedenen Stellen in der Anwendung (z.B. Graphen).
 
 ## In Arbeit
 


### PR DESCRIPTION
- Kurzen Namen für Accounts eingeführt. So kann zum Beispiel der Name "Unternehmensgruppe Sommerfeld" mit "Sommerfeld" abgekürzt werden.
- Einem Account kann eine primäre Farbe zugeordnet werden. Das kann hilfreich sein, für die Wiedererkennung an verschiedenen Stellen in der Anwendung (z.B. Graphen).