### PR TITLE
Sortierung der Kunden in Wochenplanung korrigieren

### DIFF
--- a/components/planning/usePlanAccountProjects.tsx
+++ b/components/planning/usePlanAccountProjects.tsx
@@ -1,10 +1,12 @@
-import { useAccountsContext } from "@/api/ContextAccounts";
+import { Account, useAccountsContext } from "@/api/ContextAccounts";
+import { useProjectsContext } from "@/api/ContextProjects";
 import {
   AccountProjects,
+  addEmptyAccount,
   mapAccountOrder,
   mapAccountProjects,
 } from "@/helpers/planning";
-import { filter, flow, map, sortBy } from "lodash/fp";
+import { filter, flow, identity, map, sortBy } from "lodash/fp";
 import {
   ComponentType,
   createContext,
@@ -47,19 +49,22 @@ const PlanAccountProjectsProvider: FC<PlanAccountProjectsProviderProps> = ({
 }) => {
   const { accounts, loadingAccounts, errorAccounts } = useAccountsContext();
   const { projects, saveProjectDates } = usePlanningProjectFilter();
+  const { projects: allProjects } = useProjectsContext();
   const [accountsProjects, setAccountsProjects] = useState<AccountProjects[]>(
     []
   );
 
   useEffect(() => {
     flow(
+      identity<Account[] | undefined>,
+      addEmptyAccount,
       map(mapAccountProjects(projects)),
       filter(({ projects }) => projects.length > 0),
-      map(mapAccountOrder),
+      map(mapAccountOrder(allProjects)),
       sortBy((a) => -a.order),
       setAccountsProjects
     )(accounts);
-  }, [accounts, projects]);
+  }, [accounts, projects, allProjects]);
 
   return (
     <PlanAccountProjects.Provider

--- a/components/planning/usePlanningProjectFilter.tsx
+++ b/components/planning/usePlanningProjectFilter.tsx
@@ -5,7 +5,6 @@ import {
   ProjectFilters,
   setProjectsFilterCount,
 } from "@/helpers/planning";
-import { flow } from "lodash/fp";
 import { createContext, FC, useContext, useEffect, useState } from "react";
 import { useWeekPlanContext } from "./useWeekPlanContext";
 
@@ -48,34 +47,27 @@ export const PlanningProjectFilterProvider: FC<
   const { accounts } = useAccountsContext();
   const { weekPlan, startDate } = useWeekPlanContext();
   const [projectFilter, setProjectFilter] = useState<ProjectFilters>("Open");
-  const [filteredAndSortedProjects, setFilteredAndSortedProjects] = useState(
-    filterAndSortProjectsForWeeklyPlanning(
-      accounts,
-      startDate,
-      weekPlan,
-      projectFilter
-    )(projects)
-  );
+  const [filteredAndSortedProjects, setFilteredAndSortedProjects] = useState<
+    Project[]
+  >([]);
   const [openProjectsCount, setOpenProjectsCount] = useState(0);
   const [focusProjectsCount, setFocusProjectsCount] = useState(0);
   const [onholdProjectsCount, setOnholdProjectsCount] = useState(0);
 
   useEffect(() => {
-    flow(
-      filterAndSortProjectsForWeeklyPlanning(
-        accounts,
-        startDate,
-        weekPlan,
-        projectFilter
-      ),
+    filterAndSortProjectsForWeeklyPlanning(
+      projects,
+      accounts,
+      startDate,
+      weekPlan,
+      projectFilter,
       setFilteredAndSortedProjects
-    )(projects);
+    );
   }, [accounts, projectFilter, projects, startDate, weekPlan]);
 
   useEffect(() => {
     setProjectsFilterCount(
       projects,
-      accounts,
       startDate,
       weekPlan,
       setOpenProjectsCount,

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,11 +1,7 @@
-# Tagesplanung aufräumen (Version :VERSION)
+# Sortierung der Kunden in Wochenplanung korrigieren (Version :VERSION)
 
-- In der Tagesplanung werden nun ausschließlich die Projekte ausgesucht, an denen gearbeitet werden soll.
-- Für Projekte, für die eine Entscheidung getroffen werden muss, werden die möglichen Aufgaben angezeigt und ein Akkordion für das Projekt, so dass schnell Details zum Projekt gezeigt werden können.
-- Für Projekte, die für den Tag eingeplant sind, wird nur der Projektname angezeigt.
-- Die Todoliste für den Tag zeigt nun die Projekte an, die für den Tag priorisiert wurden.
-- Projekte, die mit den Hinweis "Vielleicht" auf den Tagesplan gesetzt wurden, sind zunächst versteckt und können mit einem Klick zusätzlich angezeigt werden.
-- Auf dem Tagesplan können in den Projekten einzelne Aufgaben auf "Nicht für Heute" gesetzt werden oder wieder zurück auf den Tagesplan geführt werden.
+- In der Wochenplanung wird nun immer die gesamte Pipeline der Kunden für die Sortierung herangezogen und nicht nur die Pipeline für der Projekte, die gerade nicht auf On Hold gesetzt wurden.
+- Projekte, die keinem Kunden zugeordnet sind, werden nun auch in der Planung angezeigt.
 
 ## In Arbeit
 

--- a/helpers/planning.ts
+++ b/helpers/planning.ts
@@ -3,13 +3,11 @@ import { Project } from "@/api/ContextProjects";
 import { DailyPlan } from "@/api/useDailyPlans";
 import { WeeklyPlan } from "@/api/useWeekPlan";
 import { calcOrder } from "@/helpers/accounts";
-import { calcRevenueTwoYears, updateProjectOrder } from "@/helpers/projects";
+import { updateProjectOrder } from "@/helpers/projects";
 import { differenceInCalendarDays } from "date-fns";
 import {
-  compact,
   filter,
   find,
-  flatMap,
   flow,
   get,
   identity,
@@ -22,15 +20,29 @@ import {
 import { Dispatch, SetStateAction } from "react";
 
 export type AccountProjects = Account & { projects: Project[] };
+export type AccountPipeline = Account & { pipeline: number };
 
 export const projectFilters = ["Open", "In Focus", "On Hold"] as const;
 export type ProjectFilters = (typeof projectFilters)[number];
 
+export const getProjectsPipeline = (
+  accountId: string,
+  projects: Project[] | undefined
+) =>
+  flow(
+    identity<Project[] | undefined>,
+    filter((p) => !p.done && p.accountIds.includes(accountId)),
+    map("pipeline"),
+    sum
+  )(projects);
+
 export const filterAndSortProjectsForWeeklyPlanning = (
+  projects: Project[] | undefined,
   accounts: Account[] | undefined,
   startDate: Date,
   weekPlan: WeeklyPlan | undefined,
-  projectFilter: ProjectFilters
+  projectFilter: ProjectFilters,
+  setProjectList: (projects: Project[]) => void
 ) =>
   flow(
     filter((p: Project) => !p.done),
@@ -48,28 +60,64 @@ export const filterAndSortProjectsForWeeklyPlanning = (
               differenceInCalendarDays(p.onHoldTill, startDate) < 7)
     ),
     map(updateProjectOrder(accounts)),
-    sortBy((p) => -p.order)
-  );
+    sortBy((p) => -p.order),
+    setProjectList
+  )(projects);
+
+export const addEmptyAccount = (
+  accounts: Account[] | undefined
+): Account[] | undefined =>
+  !accounts
+    ? undefined
+    : [
+        ...accounts,
+        {
+          id: "NONE",
+          name: "No Account",
+          introduction: {},
+          latestQuota: 0,
+          pipeline: 0,
+          order: 0,
+          territoryIds: [],
+          createdAt: new Date(),
+          payerAccounts: [],
+        },
+      ];
 
 export const setProjectsFilterCount = (
   projects: Project[] | undefined,
-  accounts: Account[] | undefined,
   startDate: Date,
   weekPlan: WeeklyPlan | undefined,
   setOpenCount: (count: number) => void,
   setFocusCount: (count: number) => void,
   setOnholdCount: (count: number) => void
 ) => {
-  const simplifiedFilterFn = (projectFilter: ProjectFilters) =>
-    filterAndSortProjectsForWeeklyPlanning(
-      accounts,
-      startDate,
-      weekPlan,
-      projectFilter
-    );
-  flow(simplifiedFilterFn("Open"), size, setOpenCount)(projects);
-  flow(simplifiedFilterFn("On Hold"), size, setOnholdCount)(projects);
-  flow(simplifiedFilterFn("In Focus"), size, setFocusCount)(projects);
+  const simplifiedFilterFn = (
+    projectFilter: ProjectFilters,
+    setCount: (count: number) => void
+  ) =>
+    flow(
+      identity<Project[] | undefined>,
+      filter((p) => !p.done),
+      filter((p): boolean =>
+        projectFilter === "Open"
+          ? !weekPlan?.projectIds.includes(p.id) &&
+            (!p.onHoldTill ||
+              differenceInCalendarDays(p.onHoldTill, startDate) < 7)
+          : projectFilter === "On Hold"
+            ? !weekPlan?.projectIds.includes(p.id) &&
+              !!p.onHoldTill &&
+              differenceInCalendarDays(p.onHoldTill, startDate) >= 7
+            : !!weekPlan?.projectIds.includes(p.id) &&
+              (!p.onHoldTill ||
+                differenceInCalendarDays(p.onHoldTill, startDate) < 7)
+      ),
+      size,
+      setCount
+    )(projects);
+  simplifiedFilterFn("Open", setOpenCount);
+  simplifiedFilterFn("On Hold", setOnholdCount);
+  simplifiedFilterFn("In Focus", setFocusCount);
 };
 
 export const filterAndSortProjectsForDailyPlanning = (
@@ -112,7 +160,12 @@ export const setProjectOnDayPlanCount = (
 export const mapAccountProjects =
   (projects: Project[] | undefined) => (account: Account) => ({
     ...account,
-    projects: projects?.filter((p) => p.accountIds.includes(account.id)) ?? [],
+    projects:
+      projects?.filter((p) =>
+        account.id === "NONE"
+          ? p.accountIds.length === 0
+          : p.accountIds.includes(account.id)
+      ) ?? [],
   });
 
 export const isOnDayplan = (
@@ -143,24 +196,19 @@ export const setProjectMaybe = (
     setMaybe
   )(dayPlan);
 
-const calcPipeline: (projects: Project[]) => number = flow(
-  identity<Project[]>,
-  flatMap("crmProjects"),
-  compact,
-  map(calcRevenueTwoYears),
-  sum,
-  (val: number | undefined) => val ?? 0,
-  Math.floor
-);
+const reCalculateOrder = (
+  latestQuota: number,
+  accountId: string,
+  projects: Project[] | undefined
+) => calcOrder(latestQuota, getProjectsPipeline(accountId, projects));
 
-const reCalculateOrder = ({ latestQuota, projects }: AccountProjects) =>
-  calcOrder(latestQuota, calcPipeline(projects));
-
-export const mapAccountOrder = (account: AccountProjects): AccountProjects => ({
-  ...account,
-  order: reCalculateOrder(account),
-  pipeline: calcPipeline(account.projects),
-});
+export const mapAccountOrder =
+  (projects: Project[] | undefined) =>
+  (account: AccountProjects): AccountProjects => ({
+    ...account,
+    order: reCalculateOrder(account.latestQuota, account.id, projects),
+    pipeline: getProjectsPipeline(account.id, projects),
+  });
 
 export const isSelectedForWeek = (weekPlan: WeeklyPlan, project: Project) =>
   weekPlan.projectIds.some((id) => id === project.id);


### PR DESCRIPTION
- In der Wochenplanung wird nun immer die gesamte Pipeline der Kunden für die Sortierung herangezogen und nicht nur die Pipeline für der Projekte, die gerade nicht auf On Hold gesetzt wurden.
- Projekte, die keinem Kunden zugeordnet sind, werden nun auch in der Planung angezeigt.
