### PR TITLE
AWS Payer ID erhält ein zusätzliches Notizfeld

### DIFF
--- a/api/usePayer.ts
+++ b/api/usePayer.ts
@@ -113,6 +113,22 @@ const usePayer = (payerId?: string) => {
     return data;
   };
 
+  const deleteReseller = async () => {
+    if (!payer) return;
+    const updatedPayer = {
+      ...payer,
+      resellerId: undefined,
+    } as Payer;
+    mutate(updatedPayer, false);
+    const { data, errors } = await client.models.PayerAccount.update({
+      awsAccountNumber: payer.accountNumber,
+      resellerId: null,
+    });
+    if (errors) handleApiErrors(errors, "Deleting reseller failed");
+    mutate(updatedPayer);
+    return data;
+  };
+
   const updateNotes = async (notes: string) => {
     if (!payer) return;
     const updatedPayer = { ...payer, notes } as Payer;
@@ -133,6 +149,7 @@ const usePayer = (payerId?: string) => {
     createPayerAccountLink,
     deletePayerAccount,
     attachReseller,
+    deleteReseller,
     updateNotes,
   };
 };

--- a/components/analytics/table/render-payer-header.tsx
+++ b/components/analytics/table/render-payer-header.tsx
@@ -18,19 +18,21 @@ const RenderPayerHeader: FC<RenderPayerHeaderProps> = ({
   const { payer } = usePayer(id);
 
   return (
-    <div>
+    <div className="text-gray-500">
       {!id ? (
         label
       ) : (
         <Link
           href={`/payers/${id}`}
           target="_blank"
-          className="text-gray-500 hover:text-blue-400"
+          className="hover:text-blue-400"
         >
           {label}
           <ExternalLink className="ml-1 w-4 h-4 inline-block -translate-y-0.5" />
         </Link>
       )}
+
+      <div className="text-xs">{payer?.notes}</div>
 
       <ResellerBadge
         isReseller={isReseller}

--- a/components/payers/reseller.tsx
+++ b/components/payers/reseller.tsx
@@ -4,6 +4,7 @@ import { setResellerByPayer } from "@/helpers/analytics/account-data";
 import { FC, useEffect, useState } from "react";
 import AccountDetails from "../accounts/AccountDetails";
 import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
+import DeleteWarning from "../ui-elements/project-notes-form/DeleteWarning";
 
 type PayerResellerProps = {
   payerId: string;
@@ -12,8 +13,9 @@ type PayerResellerProps = {
 
 const PayerReseller: FC<PayerResellerProps> = ({ payerId, showReseller }) => {
   const { accounts } = useAccountsContext();
-  const { payer } = usePayer(payerId);
+  const { payer, deleteReseller } = usePayer(payerId);
   const [reseller, setReseller] = useState<Account | undefined>();
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
 
   useEffect(() => {
     setResellerByPayer(payer, accounts, setReseller);
@@ -21,14 +23,24 @@ const PayerReseller: FC<PayerResellerProps> = ({ payerId, showReseller }) => {
 
   return (
     reseller && (
-      <DefaultAccordionItem
-        value="reseller"
-        triggerTitle={`Reseller: ${reseller?.name}`}
-        link={`/accounts/${reseller?.id}`}
-        isVisible={!!showReseller}
-      >
-        <AccountDetails account={reseller} showResellerFinancials />
-      </DefaultAccordionItem>
+      <>
+        <DeleteWarning
+          open={showDeleteConfirmation}
+          onOpenChange={setShowDeleteConfirmation}
+          confirmText={`Are you sure you want to remove the reseller "${reseller.name}" from the Payer Account?`}
+          onConfirm={deleteReseller}
+        />
+
+        <DefaultAccordionItem
+          value="reseller"
+          triggerTitle={`Reseller: ${reseller?.name}`}
+          link={`/accounts/${reseller?.id}`}
+          isVisible={!!showReseller}
+          onDelete={() => setShowDeleteConfirmation(true)}
+        >
+          <AccountDetails account={reseller} showResellerFinancials />
+        </DefaultAccordionItem>
+      </>
     )
   );
 };

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,14 +1,13 @@
 # AWS Payer ID erhält ein zusätzliches Notizfeld (Version :VERSION)
 
 Damit können Bemerkungen für einen Account hinterlassen werden.
+Die Bemerkungen werden in der Tabelle mit den Finanzdaten mit angezeigt.
 
 ## Fehlerbehebungen
 
 - Wenn versehentlich ein Reseller bei einer Account ID hinzugefügt wurde, kann dieser nun wieder gelöscht werden.
 
 ## In Arbeit
-
-- Die Bemerkungen werden in der Tabelle mit den Finanzdaten mit angezeigt.
 
 ## Geplant
 

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -2,7 +2,13 @@
 
 Damit können Bemerkungen für einen Account hinterlassen werden.
 
+## Fehlerbehebungen
+
+- Wenn versehentlich ein Reseller bei einer Account ID hinzugefügt wurde, kann dieser nun wieder gelöscht werden.
+
 ## In Arbeit
+
+- Die Bemerkungen werden in der Tabelle mit den Finanzdaten mit angezeigt.
 
 ## Geplant
 

--- a/helpers/analytics/account-data.tsx
+++ b/helpers/analytics/account-data.tsx
@@ -147,10 +147,9 @@ export const setResellerByPayer = (
   accounts: Account[] | undefined,
   setReseller: Dispatch<SetStateAction<Account | undefined>>
 ) =>
-  payer?.resellerId &&
   flow(
     identity<Account[] | undefined>,
-    find(["id", payer.resellerId]),
+    find(["id", payer?.resellerId]),
     setReseller
   )(accounts);
 


### PR DESCRIPTION
Damit können Bemerkungen für einen Account hinterlassen werden.
Die Bemerkungen werden in der Tabelle mit den Finanzdaten mit angezeigt.

## Fehlerbehebungen

- Wenn versehentlich ein Reseller bei einer Account ID hinzugefügt wurde, kann dieser nun wieder gelöscht werden.