### PR TITLE
AWS Payer ID Person zuordnen

### DIFF
--- a/api/usePayer.ts
+++ b/api/usePayer.ts
@@ -99,6 +99,36 @@ const usePayer = (payerId?: string) => {
     mutate(updated);
   };
 
+  const attachPerson = async (personId: string | null) => {
+    if (!personId) return;
+    if (!payer) return;
+    const updatedPayer = { ...payer, mainContactId: personId } as Payer;
+    mutate(updatedPayer, false);
+    const { data, errors } = await client.models.PayerAccount.update({
+      awsAccountNumber: payer.accountNumber,
+      mainContactId: personId,
+    });
+    if (errors) handleApiErrors(errors, "Attaching person failed");
+    mutate(updatedPayer);
+    return data;
+  };
+
+  const deletePerson = async () => {
+    if (!payer) return;
+    const updatedPayer = {
+      ...payer,
+      mainContactId: undefined,
+    } as Payer;
+    mutate(updatedPayer, false);
+    const { data, errors } = await client.models.PayerAccount.update({
+      awsAccountNumber: payer.accountNumber,
+      mainContactId: null,
+    });
+    if (errors) handleApiErrors(errors, "Deleting person failed");
+    mutate(updatedPayer);
+    return data;
+  };
+
   const attachReseller = async (resellerId: string | null) => {
     if (!resellerId) return;
     if (!payer) return;
@@ -150,6 +180,8 @@ const usePayer = (payerId?: string) => {
     deletePayerAccount,
     attachReseller,
     deleteReseller,
+    attachPerson,
+    deletePerson,
     updateNotes,
   };
 };

--- a/components/analytics/table/render-payer-header.tsx
+++ b/components/analytics/table/render-payer-header.tsx
@@ -1,4 +1,5 @@
 import usePayer from "@/api/usePayer";
+import PayerHeaderPerson from "@/components/payers/header-person";
 import ResellerBadge from "@/components/payers/reseller-badge";
 import { ExternalLink } from "lucide-react";
 import Link from "next/link";
@@ -31,6 +32,11 @@ const RenderPayerHeader: FC<RenderPayerHeaderProps> = ({
           <ExternalLink className="ml-1 w-4 h-4 inline-block -translate-y-0.5" />
         </Link>
       )}
+
+      <PayerHeaderPerson
+        personId={payer?.mainContactId}
+        textResellerSize="xs"
+      />
 
       <div className="text-xs">{payer?.notes}</div>
 

--- a/components/payers/details.tsx
+++ b/components/payers/details.tsx
@@ -2,16 +2,19 @@ import usePayer from "@/api/usePayer";
 import { Accordion } from "@/components/ui/accordion";
 import { FC } from "react";
 import AccountSelector from "../ui-elements/selectors/account-selector";
+import PeopleSelector from "../ui-elements/selectors/people-selector";
 import PayerAccounts from "./accounts";
 import PayerFinancials from "./financials";
 import NotesInput from "./notes-input";
 import PayerReseller from "./reseller";
+import PayerPerson from "./person";
 
 type PayerDetailsProps = {
   showLinkedAccounts?: boolean;
   showFinancials?: boolean;
   showNotes?: boolean;
   showReseller?: boolean;
+  showPerson?: boolean;
   payerId: string | undefined;
 };
 
@@ -21,8 +24,10 @@ const PayerDetails: FC<PayerDetailsProps> = ({
   showFinancials = true,
   showLinkedAccounts = true,
   showReseller = true,
+  showPerson = true,
 }) => {
-  const { attachReseller, payer, updateNotes } = usePayer(payerId);
+  const { attachReseller, payer, updateNotes, attachPerson } =
+    usePayer(payerId);
 
   return (
     payerId && (
@@ -39,6 +44,14 @@ const PayerDetails: FC<PayerDetailsProps> = ({
           />
         </div>
 
+        <div className="mt-2">
+          <PeopleSelector
+            value=""
+            onChange={attachPerson}
+            placeholder="Attach person…"
+          />
+        </div>
+
         <PayerAccounts
           payerId={payerId}
           showLinkedAccounts={showLinkedAccounts}
@@ -47,6 +60,8 @@ const PayerDetails: FC<PayerDetailsProps> = ({
         <PayerFinancials payerId={payerId} showFinancials={showFinancials} />
 
         <PayerReseller payerId={payerId} showReseller={showReseller} />
+
+        <PayerPerson payerId={payerId} showPerson={showPerson} />
       </Accordion>
     )
   );

--- a/components/payers/header-person.tsx
+++ b/components/payers/header-person.tsx
@@ -1,0 +1,48 @@
+import usePeople from "@/api/usePeople";
+import { cn } from "@/lib/utils";
+import { flow, identity } from "lodash/fp";
+import { ExternalLink } from "lucide-react";
+import Link from "next/link";
+import { FC, useEffect, useState } from "react";
+
+type PayerHeaderPersonProps = {
+  personId?: string;
+  className?: string;
+  textResellerSize?: "sm" | "xs";
+};
+
+const PayerHeaderPerson: FC<PayerHeaderPersonProps> = ({
+  personId,
+  className,
+  textResellerSize = "sm",
+}) => {
+  const { getNamesByIds } = usePeople();
+  const [personName, setPersonName] = useState<string | undefined>();
+
+  useEffect(() => {
+    flow(
+      identity<string | undefined>,
+      (id) => (!id ? undefined : getNamesByIds([id])),
+      setPersonName
+    )(personId);
+  }, [personId, getNamesByIds]);
+
+  return (
+    personName && (
+      <div className={cn("flex flex-col", className)}>
+        <Link
+          className={cn(
+            textResellerSize === "sm" ? "text-sm" : "text-xs",
+            "text-muted-foreground hover:text-blue-600"
+          )}
+          href={`/people/${personId}`}
+        >
+          {personName}
+          <ExternalLink className="w-3 h-3 inline-block ml-1 -translate-y-0.5" />
+        </Link>
+      </div>
+    )
+  );
+};
+
+export default PayerHeaderPerson;

--- a/components/payers/person.tsx
+++ b/components/payers/person.tsx
@@ -1,0 +1,56 @@
+import usePayer from "@/api/usePayer";
+import { FC, useEffect, useState } from "react";
+import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
+import DeleteWarning from "../ui-elements/project-notes-form/DeleteWarning";
+import usePeople, { LeanPerson } from "@/api/usePeople";
+import { flow, identity, find } from "lodash/fp";
+import PersonDetails from "../people/PersonDetails";
+
+type PayerPersonProps = {
+  payerId: string;
+  showPerson?: boolean;
+};
+
+const PayerPerson: FC<PayerPersonProps> = ({ payerId, showPerson }) => {
+  const { payer, deletePerson } = usePayer(payerId);
+  const { people, getNamesByIds } = usePeople();
+  const [person, setPerson] = useState<LeanPerson | undefined>();
+  const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
+
+  useEffect(() => {
+    flow(
+      identity<LeanPerson[] | undefined>,
+      find(["id", payer?.mainContactId]),
+      setPerson
+    )(people);
+  }, [payer, people]);
+
+  return (
+    person && (
+      <>
+        <DeleteWarning
+          open={showDeleteConfirmation}
+          onOpenChange={setShowDeleteConfirmation}
+          confirmText={`Are you sure you want to remove the person "${person.name}" from the Payer Account?`}
+          onConfirm={deletePerson}
+        />
+
+        <DefaultAccordionItem
+          value="main-contact"
+          triggerTitle={
+            !payer?.mainContactId
+              ? undefined
+              : `Main Contact: ${getNamesByIds([payer.mainContactId])}`
+          }
+          link={`/people/${person?.id}`}
+          isVisible={!!showPerson}
+          onDelete={() => setShowDeleteConfirmation(true)}
+        >
+          <PersonDetails personId={person?.id} />
+        </DefaultAccordionItem>
+      </>
+    )
+  );
+};
+
+export default PayerPerson;

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,10 +1,9 @@
 # AWS Payer ID Person zuordnen (Version :VERSION)
 
 - Person kann einer Payer ID als primärer Kontakt zugeordnet werden
+- Verlinkte Person wird in den Finanzdaten angezeigt
 
 ## In Arbeit
-
-- Person in den Finanzdaten anzeigen
 
 ## Geplant
 

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,13 +1,10 @@
-# AWS Payer ID erhält ein zusätzliches Notizfeld (Version :VERSION)
+# AWS Payer ID Person zuordnen (Version :VERSION)
 
-Damit können Bemerkungen für einen Account hinterlassen werden.
-Die Bemerkungen werden in der Tabelle mit den Finanzdaten mit angezeigt.
-
-## Fehlerbehebungen
-
-- Wenn versehentlich ein Reseller bei einer Account ID hinzugefügt wurde, kann dieser nun wieder gelöscht werden.
+- Person kann einer Payer ID als primärer Kontakt zugeordnet werden
 
 ## In Arbeit
+
+- Person in den Finanzdaten anzeigen
 
 ## Geplant
 

--- a/pages/payers/[id].tsx
+++ b/pages/payers/[id].tsx
@@ -5,7 +5,7 @@ import PayerDetails from "@/components/payers/details";
 import ResellerBadge from "@/components/payers/reseller-badge";
 import { useRouter } from "next/router";
 
-const ProjectDetailPage = () => {
+const PayerDetailPage = () => {
   const router = useRouter();
   const { id } = router.query;
   const payerId = Array.isArray(id) ? id[0] : id;
@@ -30,4 +30,4 @@ const ProjectDetailPage = () => {
     </MainLayout>
   );
 };
-export default ProjectDetailPage;
+export default PayerDetailPage;


### PR DESCRIPTION
- Person kann einer Payer ID als primärer Kontakt zugeordnet werden
- Verlinkte Person wird in den Finanzdaten angezeigt
