### PR TITLE
Gelerntes über Unternehmen festhalten

### DIFF
--- a/amplify/data/account-schema.ts
+++ b/amplify/data/account-schema.ts
@@ -7,8 +7,8 @@ export const tablesWithDeleteProtection = [
   "AccountPayerAccount",
   "PayerAccount",
   "Account",
-  "AccountLearning",
-  "AccountLearningPerson",
+  // "AccountLearning",
+  // "AccountLearningPerson",
 ];
 
 const accountSchema = {

--- a/amplify/data/account-schema.ts
+++ b/amplify/data/account-schema.ts
@@ -7,6 +7,8 @@ export const tablesWithDeleteProtection = [
   "AccountPayerAccount",
   "PayerAccount",
   "Account",
+  "AccountLearning",
+  "AccountLearningPerson",
 ];
 
 const accountSchema = {

--- a/api/useAccountLearnings.ts
+++ b/api/useAccountLearnings.ts
@@ -1,0 +1,226 @@
+import { type Schema } from "@/amplify/data/resource";
+import { emptyDocument } from "@/components/ui-elements/editors/helpers/document";
+import { toast } from "@/components/ui/use-toast";
+import { invertSign, not, toISODateString } from "@/helpers/functional";
+import { transformNotesVersion } from "@/helpers/ui-notes-writer";
+import { JSONContent } from "@tiptap/core";
+import { generateClient } from "aws-amplify/data";
+import { getTime } from "date-fns";
+import {
+  filter,
+  flatMap,
+  flow,
+  get,
+  identity,
+  includes,
+  map,
+  sortBy,
+  uniq,
+} from "lodash/fp";
+import useSWR from "swr";
+import { handleApiErrors } from "./globals";
+
+const client = generateClient<Schema>();
+
+export type AccountLearning = {
+  id: string;
+  learning: JSONContent;
+  learnedOn: Date;
+  updatedAt: Date;
+};
+
+type AccountLearningData = Schema["AccountLearning"]["type"];
+
+const mapLearning = ({
+  id,
+  createdAt,
+  updatedAt,
+  learnedOn,
+  learning,
+}: AccountLearningData): AccountLearning => ({
+  id,
+  learning: transformNotesVersion({
+    formatVersion: 2,
+    notes: "",
+    notesJson: learning,
+  }),
+  learnedOn: new Date(learnedOn || createdAt),
+  updatedAt: new Date(updatedAt),
+});
+
+const fetchLearnings = (accountId?: string) => async () => {
+  if (!accountId) return;
+  const { data, errors } =
+    await client.models.AccountLearning.listAccountLearningByAccountId(
+      { accountId },
+      { filter: { status: { eq: "new" } } }
+    );
+  if (errors) {
+    handleApiErrors(errors, "Loading learnings about account failed");
+    throw errors;
+  }
+  try {
+    return flow(
+      map(mapLearning),
+      sortBy(
+        flow(identity<AccountLearning>, get("learnedOn"), getTime, invertSign)
+      )
+    )(data);
+  } catch (error) {
+    console.error("fetchLearnings", error);
+    throw error;
+  }
+};
+
+const useAccountLearnings = (accountId?: string) => {
+  const {
+    data: learnings,
+    isLoading,
+    error,
+    mutate,
+  } = useSWR(`/api/accounts/${accountId}/learnings`, fetchLearnings(accountId));
+
+  const createLearning = async () => {
+    if (!accountId) return;
+    const updated = [
+      {
+        id: crypto.randomUUID(),
+        learnedOn: new Date(),
+        learning: emptyDocument,
+        updatedAt: new Date(),
+      } as AccountLearning,
+      ...(learnings || []),
+    ];
+    mutate(updated, false);
+    const { data, errors } = await client.models.AccountLearning.create({
+      accountId,
+      learnedOn: toISODateString(new Date()),
+      status: "new",
+    });
+    if (errors) handleApiErrors(errors, "Creating learning on account failed");
+    mutate(updated);
+    return data?.id;
+  };
+
+  const deleteLearning = async (learningId: string) => {
+    const updated = learnings?.filter((l) => l.id !== learningId);
+    if (updated) mutate(updated, false);
+    const { data, errors } = await client.models.AccountLearning.delete({
+      id: learningId,
+    });
+    if (errors) handleApiErrors(errors, "Deleting learning failed");
+    if (updated) mutate(updated);
+    if (!data) return;
+    toast({ title: "Learning about account deleted" });
+    return data.id;
+  };
+
+  const updateDate = async (learningId: string, date: Date) => {
+    const updated = learnings?.map((l) =>
+      l.id !== learningId ? l : { ...l, learnedOn: date }
+    );
+    if (updated) mutate(updated, false);
+    const { data, errors } = await client.models.AccountLearning.update({
+      id: learningId,
+      learnedOn: toISODateString(date),
+    });
+    if (errors) handleApiErrors(errors, "Updating learning's date failed");
+    if (updated) mutate(updated);
+    return data?.id;
+  };
+
+  const getMentionedPeople = async (learningId: string) => {
+    const { data, errors } =
+      await client.models.AccountLearningPerson.listAccountLearningPersonByLearningId(
+        { learningId },
+        { selectionSet: ["id", "personId"] }
+      );
+    if (errors) handleApiErrors(errors, "Loading mentioned people failed");
+    return data;
+  };
+
+  const addMentionedPerson = async (learningId: string, personId: string) => {
+    const { data, errors } = await client.models.AccountLearningPerson.create({
+      learningId,
+      personId,
+    });
+    if (errors) handleApiErrors(errors, "Adding mentioned person failed");
+    return data?.personId;
+  };
+
+  const removeMentionedPerson = async (recordId: string) => {
+    const { data, errors } = await client.models.AccountLearningPerson.delete({
+      id: recordId,
+    });
+    if (errors) handleApiErrors(errors, "Removing mentioned person failed");
+    return data?.personId;
+  };
+
+  const updateMentionedPeople = async (
+    learningId: string,
+    learning: JSONContent
+  ) => {
+    const peopleIds = flow(
+      identity<JSONContent>,
+      get("content"),
+      flatMap("content"),
+      filter({ type: "mention" }),
+      map("attrs.id"),
+      uniq
+    )(learning) as string[];
+    const existingPeople = await getMentionedPeople(learningId);
+    const toAdd = peopleIds.filter((id) =>
+      flow(
+        identity<typeof existingPeople>,
+        map("personId"),
+        includes(id),
+        not
+      )(existingPeople)
+    );
+    const toRemove = flow(
+      identity<typeof existingPeople>,
+      filter(({ personId }) => !peopleIds.includes(personId)),
+      map("id")
+    )(existingPeople);
+    const added = await Promise.all(
+      toAdd.map((personId) => addMentionedPerson(learningId, personId))
+    );
+    const removed = await Promise.all(toRemove.map(removeMentionedPerson));
+    return { added, removed };
+  };
+
+  const updateLearning = async (learningId: string, learning: JSONContent) => {
+    if (!learnings) return;
+    const updated = learnings.map((l) =>
+      l.id !== learningId
+        ? l
+        : ({
+            ...l,
+            learning,
+            updatedAt: new Date(),
+          } as AccountLearning)
+    );
+    mutate(updated, false);
+    const { data, errors } = await client.models.AccountLearning.update({
+      id: learningId,
+      learning: JSON.stringify(learning),
+    });
+    if (errors)
+      handleApiErrors(errors, "Error updating learning about account");
+    mutate(updated);
+    await updateMentionedPeople(learningId, learning);
+    return data?.id;
+  };
+
+  return {
+    learnings,
+    isLoading,
+    error,
+    createLearning,
+    deleteLearning,
+    updateLearning,
+    updateDate,
+  };
+};
+
+export default useAccountLearnings;

--- a/api/useInbox.ts
+++ b/api/useInbox.ts
@@ -189,6 +189,7 @@ const useInbox = () => {
       learnedOn: toISODateString(item.createdAt),
       learning: stringifyBlock(item.note),
       prayer: !withPrayer ? undefined : "PRAYING",
+      status: "new",
     });
     if (errors) handleApiErrors(errors, "Error moving inbox item to person");
     if (updated) mutate(updated);

--- a/components/accounts/AccountDetails.tsx
+++ b/components/accounts/AccountDetails.tsx
@@ -4,6 +4,7 @@ import CrmLink from "../crm/CrmLink";
 import { Accordion } from "../ui/accordion";
 import AccountFinancials from "./AccountFinancials";
 import AccountIntroduction from "./AccountIntroduction";
+import AccountLearnings from "./AccountLearnings";
 import AccountNotes from "./AccountNotes";
 import AccountPayerAccounts from "./AccountPayerAccounts";
 import AccountPeople from "./AccountPeople";
@@ -73,6 +74,7 @@ const AccountDetails: FC<AccountDetailsProps> = ({
         />
 
         <AccountIntroduction {...{ account, showIntroduction }} />
+        <AccountLearnings accountId={account.id} />
         <AccountProjects {...{ account, showProjects }} />
         <AccountPeople accountId={account.id} isVisible={!!showContacts} />
         <AccountNotes accountId={account.id} />

--- a/components/accounts/AccountLearnings.tsx
+++ b/components/accounts/AccountLearnings.tsx
@@ -1,0 +1,100 @@
+import useAccountLearnings from "@/api/useAccountLearnings";
+import { Editor, JSONContent } from "@tiptap/core";
+import { debounce } from "lodash";
+import { flow, map } from "lodash/fp";
+import { PlusCircle } from "lucide-react";
+import { FC, useState } from "react";
+import LearningComponent from "../learnings/LearningComponent";
+import DefaultAccordionItem from "../ui-elements/accordion/DefaultAccordionItem";
+import LoadingAccordionItem from "../ui-elements/accordion/LoadingAccordionItem";
+import { getTextFromJsonContent } from "../ui-elements/editors/helpers/text-generation";
+import { Button } from "../ui/button";
+
+interface AccountLearningsProps {
+  accountId?: string;
+}
+
+type DebouncedUpdateLearningsProps = {
+  learningId: string;
+  updateLearning: (learningId: string, learning: JSONContent) => void;
+  editor: Editor;
+};
+
+const debouncedUpdateLearnings = debounce(
+  async ({
+    learningId,
+    updateLearning,
+    editor,
+  }: DebouncedUpdateLearningsProps) => {
+    await updateLearning(learningId, editor.getJSON());
+  },
+  1500
+);
+
+const AccountLearnings: FC<AccountLearningsProps> = ({ accountId }) => {
+  const {
+    learnings,
+    createLearning,
+    deleteLearning,
+    updateLearning,
+    updateDate,
+  } = useAccountLearnings(accountId);
+  const [editId, setEditId] = useState<string | null>(null);
+
+  const handleCreate = async () => {
+    const newId = await createLearning();
+    if (newId) setEditId(newId);
+  };
+
+  const handleLearningUpdate = (learningId: string) => (editor: Editor) => {
+    debouncedUpdateLearnings({
+      learningId,
+      updateLearning,
+      editor,
+    });
+  };
+
+  return !accountId ? (
+    <LoadingAccordionItem
+      value="loading-learnings"
+      sizeTitle="sm"
+      sizeSubtitle="xl"
+    />
+  ) : (
+    <DefaultAccordionItem
+      value="learnings"
+      triggerTitle="Learnings"
+      triggerSubTitle={
+        learnings &&
+        flow(
+          (l) => l.slice(0, 2),
+          map("learning"),
+          map(getTextFromJsonContent)
+        )(learnings)
+      }
+    >
+      <div className="space-y-4">
+        <Button size="sm" className="gap-1" onClick={handleCreate}>
+          <PlusCircle className="w-4 h-4" />
+          Learning
+        </Button>
+
+        {learnings?.map((learning) => (
+          <LearningComponent
+            key={learning.id}
+            learning={learning}
+            editable={learning.id === editId}
+            onMakeEditable={() =>
+              setEditId(editId === learning.id ? null : learning.id)
+            }
+            onDelete={() => deleteLearning(learning.id)}
+            onChange={handleLearningUpdate(learning.id)}
+            onDateChange={(date) => updateDate(learning.id, date)}
+          />
+        ))}
+      </div>
+    </DefaultAccordionItem>
+  );
+};
+
+export default AccountLearnings;

--- a/components/learnings/LearningComponent.tsx
+++ b/components/learnings/LearningComponent.tsx
@@ -1,6 +1,5 @@
-import { PersonLearning } from "@/api/usePersonLearnings";
 import { cn } from "@/lib/utils";
-import { Editor } from "@tiptap/core";
+import { Editor, JSONContent } from "@tiptap/core";
 import { format } from "date-fns";
 import { Check, Edit, Trash2 } from "lucide-react";
 import { FC, useState } from "react";
@@ -9,14 +8,22 @@ import NotesWriter from "../ui-elements/notes-writer/NotesWriter";
 import DateSelector from "../ui-elements/selectors/date-selector";
 import { Button } from "../ui/button";
 
+interface ILearning {
+  id: string;
+  learning: JSONContent;
+  learnedOn: Date;
+  updatedAt: Date;
+  prayerStatus?: TPrayerStatus;
+}
+
 type LearningComponentProps = {
-  learning: PersonLearning;
+  learning: ILearning;
   editable?: boolean;
   onMakeEditable?: () => void;
   onDelete?: () => void;
   onChange: (editor: Editor) => void;
-  onStatusChange: (val: TPrayerStatus) => void;
   onDateChange: (newDate: Date) => Promise<string | undefined>;
+  onStatusChange?: (val: TPrayerStatus) => void;
 };
 
 const LearningComponent: FC<LearningComponentProps> = ({
@@ -74,11 +81,15 @@ const LearningComponent: FC<LearningComponentProps> = ({
           </Button>
         )}
       </h3>
-      <PrayerStatus
-        status={learning.prayerStatus}
-        onChange={onStatusChange}
-        editable={!!editable}
-      />
+
+      {onStatusChange && learning.prayerStatus && (
+        <PrayerStatus
+          status={learning.prayerStatus}
+          onChange={onStatusChange}
+          editable={!!editable}
+        />
+      )}
+
       <div className={cn(!editable && "-mx-2")}>
         <NotesWriter
           readonly={!editable}

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,6 +1,8 @@
 # Gelerntes über Unternehmen festhalten (Version :VERSION)
 
 - Datenbankschema angepasst, um Gelerntes über Unternehmen speichern zu können.
+- Gelerntes über eine Organisation kann erfasst werden.
+- Personen können in Gelerntes zu Organisationen markiert werden.
 
 ## Weitere Änderungen
 
@@ -11,7 +13,6 @@
 
 ## In Arbeit
 
-- Gelerntes über eine Organisation kann erfasst werden.
 - Etwas Gelerntes über Unternehmen kann als "nicht mehr relevant" markiert werden.
 - Etwas Gelerntes über Personen kann als "nicht mehr relevant" markiert werden.
 

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -5,8 +5,6 @@
 - Personen können in Gelerntes zu Organisationen markiert werden.
 - Im Chatbot wird auch Gelerntes zu Organsiationen berücksichtigt, wenn die Person darin erwähnt wird.
 
-## Weitere Änderungen
-
 ## Bekannte Fehler
 
 - Bei längeren Antworten, die der Chatbot generiert, überschreibt er seine Antwort irgendwann selbst.

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -3,6 +3,7 @@
 - Datenbankschema angepasst, um Gelerntes über Unternehmen speichern zu können.
 - Gelerntes über eine Organisation kann erfasst werden.
 - Personen können in Gelerntes zu Organisationen markiert werden.
+- Im Chatbot wird auch Gelerntes zu Organsiationen berücksichtigt, wenn die Person darin erwähnt wird.
 
 ## Weitere Änderungen
 


### PR DESCRIPTION
- Datenbankschema angepasst, um Gelerntes über Unternehmen speichern zu können.
- Gelerntes über eine Organisation kann erfasst werden.
- Personen können in Gelerntes zu Organisationen markiert werden.
- Im Chatbot wird auch Gelerntes zu Organsiationen berücksichtigt, wenn die Person darin erwähnt wird.

## Bekannte Fehler

- Bei längeren Antworten, die der Chatbot generiert, überschreibt er seine Antwort irgendwann selbst.
- Wenn ein neuer Chat geöffnet wird, könnten während des Ladens Neuigkeiten gestreamt, die von der UI nicht erfasst werden. Dadurch wirkt der Text am Anfang abgehackt.
