### PR TITLE
Gelerntes über Unternehmen

### DIFF
--- a/amplify/data/resource.ts
+++ b/amplify/data/resource.ts
@@ -68,6 +68,7 @@ const schema = a
         status: a.ref("InboxStatus").required(),
         movedToActivityId: a.string(),
         movedToPersonLearningId: a.string(),
+        movedToAccountLearningId: a.string(),
         createdAt: a.datetime().required(),
       })
       .secondaryIndexes((inbox) => [

--- a/api/helpers/account-learning.ts
+++ b/api/helpers/account-learning.ts
@@ -1,0 +1,77 @@
+import { type Schema } from "@/amplify/data/resource";
+import { not } from "@/helpers/functional";
+import { JSONContent } from "@tiptap/core";
+import { generateClient } from "aws-amplify/data";
+import {
+  filter,
+  flatMap,
+  flow,
+  get,
+  identity,
+  includes,
+  map,
+  uniq,
+} from "lodash/fp";
+import { handleApiErrors } from "../globals";
+
+const client = generateClient<Schema>();
+
+const getMentionedPeople = async (learningId: string) => {
+  const { data, errors } =
+    await client.models.AccountLearningPerson.listAccountLearningPersonByLearningId(
+      { learningId },
+      { selectionSet: ["id", "personId"] }
+    );
+  if (errors) handleApiErrors(errors, "Loading mentioned people failed");
+  return data;
+};
+
+const addMentionedPerson = async (learningId: string, personId: string) => {
+  const { data, errors } = await client.models.AccountLearningPerson.create({
+    learningId,
+    personId,
+  });
+  if (errors) handleApiErrors(errors, "Adding mentioned person failed");
+  return data?.personId;
+};
+
+const removeMentionedPerson = async (recordId: string) => {
+  const { data, errors } = await client.models.AccountLearningPerson.delete({
+    id: recordId,
+  });
+  if (errors) handleApiErrors(errors, "Removing mentioned person failed");
+  return data?.personId;
+};
+
+export const updateMentionedPeople = async (
+  learningId: string,
+  learning: JSONContent
+) => {
+  const peopleIds = flow(
+    identity<JSONContent>,
+    get("content"),
+    flatMap("content"),
+    filter({ type: "mention" }),
+    map("attrs.id"),
+    uniq
+  )(learning) as string[];
+  const existingPeople = await getMentionedPeople(learningId);
+  const toAdd = peopleIds.filter((id) =>
+    flow(
+      identity<typeof existingPeople>,
+      map("personId"),
+      includes(id),
+      not
+    )(existingPeople)
+  );
+  const toRemove = flow(
+    identity<typeof existingPeople>,
+    filter(({ personId }) => !peopleIds.includes(personId)),
+    map("id")
+  )(existingPeople);
+  const added = await Promise.all(
+    toAdd.map((personId) => addMentionedPerson(learningId, personId))
+  );
+  const removed = await Promise.all(toRemove.map(removeMentionedPerson));
+  return { added, removed };
+};

--- a/components/inbox/InboxDecisionMenu.tsx
+++ b/components/inbox/InboxDecisionMenu.tsx
@@ -1,6 +1,7 @@
 import { flow, identity } from "lodash/fp";
 import { Undo2 } from "lucide-react";
 import { FC, useEffect, useState } from "react";
+import AccountSelector from "../ui-elements/selectors/account-selector";
 import PeopleSelector from "../ui-elements/selectors/people-selector";
 import ProjectSelector from "../ui-elements/selectors/project-selector";
 import ConfirmContent from "./ConfirmContent";
@@ -20,17 +21,20 @@ type InboxDecisionMenuProps = {
   setInboxItemDone: () => void;
   addToProject: (projectId: string) => void;
   addToPerson: (personId: string, withPrayer?: boolean) => void;
+  addToAccount: (accountId: string) => void;
 };
 
 const InboxDecisionMenu: FC<InboxDecisionMenuProps> = ({
   setInboxItemDone,
   addToProject,
   addToPerson,
+  addToAccount,
 }) => {
   const [status, setStatus] = useState<WorkflowStatus>("new");
   const [step, setStep] = useState<WorkflowStep | null>(null);
   const [selectedProject, setSelectedProject] = useState<string | null>(null);
   const [selectedPerson, setSelectedPerson] = useState<string | null>(null);
+  const [selectedAccount, setSelectedAccount] = useState<string | null>(null);
 
   useEffect(() => {
     flow(identity<WorkflowStep>, findStepByStatus(status), setStep)(workflow);
@@ -57,6 +61,10 @@ const InboxDecisionMenu: FC<InboxDecisionMenuProps> = ({
         if (!selectedPerson) return;
         addToPerson(selectedPerson, true);
       },
+      addToAccount: () => {
+        if (!selectedAccount) return;
+        addToAccount(selectedAccount);
+      },
     };
     actions[actionStatus]();
   };
@@ -79,6 +87,14 @@ const InboxDecisionMenu: FC<InboxDecisionMenuProps> = ({
             value={selectedPerson ?? ""}
             onChange={setSelectedPerson}
             allowNewPerson
+          />
+        )}
+
+        {step.status === "addToAccount" && (
+          <AccountSelector
+            value={selectedAccount ?? ""}
+            onChange={setSelectedAccount}
+            allowCreateAccounts
           />
         )}
 

--- a/components/inbox/ProcessInboxItem.tsx
+++ b/components/inbox/ProcessInboxItem.tsx
@@ -16,6 +16,7 @@ const ProcessInboxItem = () => {
     setInboxItemDone,
     moveItemToProject,
     moveItemToPerson,
+    moveItemToAccount,
   } = useInbox();
   const [firstItem, setFirstItem] = useState<Inbox | undefined>();
 
@@ -44,6 +45,9 @@ const ProcessInboxItem = () => {
             }
             addToPerson={(personId, withPrayer) =>
               moveItemToPerson(firstItem, personId, withPrayer)
+            }
+            addToAccount={(accountId) =>
+              moveItemToAccount(firstItem, accountId)
             }
           />
 

--- a/components/inbox/helpers.ts
+++ b/components/inbox/helpers.ts
@@ -83,3 +83,16 @@ export const updateMovedItemToPersonId = async (
   if (errors) handleApiErrors(errors, "Linking inbox item/person failed");
   return data?.id;
 };
+
+export const updateMovedItemToAccountId = async (
+  inboxItemId: string,
+  accountLearningId: string
+) => {
+  const { data, errors } = await client.models.Inbox.update({
+    id: inboxItemId,
+    movedToAccountLearningId: accountLearningId,
+    status: "done",
+  });
+  if (errors) handleApiErrors(errors, "Linking inbox item/account failed");
+  return data?.id;
+};

--- a/components/inbox/inboxWorkflow.ts
+++ b/components/inbox/inboxWorkflow.ts
@@ -1,5 +1,6 @@
 import {
   BookOpenCheck,
+  Building,
   Check,
   CloudLightning,
   HandHelping,
@@ -18,6 +19,7 @@ export type WorkflowStatus =
   | "addToProject"
   | "addToPerson"
   | "addToPersonWithPrayer"
+  | "addToAccount"
   | "confirmDeletion"
   | "done";
 export type WorkflowStepIcon = typeof Stars;
@@ -26,12 +28,14 @@ export type WorkflowStatusWithActions =
   | "addToProject"
   | "addToPerson"
   | "addToPersonWithPrayer"
+  | "addToAccount"
   | "done";
 
 export const statusWithAction = [
   "addToProject",
   "addToPerson",
   "addToPersonWithPrayer",
+  "addToAccount",
   "done",
 ] as const;
 
@@ -128,6 +132,23 @@ export const workflow: WorkflowStart = {
               status: "addToPerson",
               statusName: "Done",
               StepIcon: X,
+              question: "Done!",
+              takeAction: true,
+            },
+          ],
+        },
+        {
+          decisionName: "Account",
+          status: "addToAccount",
+          statusName: "Add to account",
+          StepIcon: Building,
+          question: "Select Account:",
+          responses: [
+            {
+              decisionName: "Done",
+              status: "addToAccount",
+              statusName: "Done",
+              StepIcon: Check,
               question: "Done!",
               takeAction: true,
             },

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -4,6 +4,7 @@
 - Gelerntes über eine Organisation kann erfasst werden.
 - Personen können in Gelerntes zu Organisationen markiert werden.
 - Im Chatbot wird auch Gelerntes zu Organsiationen berücksichtigt, wenn die Person darin erwähnt wird.
+- Auch aus der Inbox heraus können Einträge als Gelerntes über Organisationen übertragen werden.
 
 ## Bekannte Fehler
 


### PR DESCRIPTION
- Datenbankschema angepasst, um Gelerntes über Unternehmen speichern zu können.
- Gelerntes über eine Organisation kann erfasst werden.
- Personen können in Gelerntes zu Organisationen markiert werden.
- Im Chatbot wird auch Gelerntes zu Organsiationen berücksichtigt, wenn die Person darin erwähnt wird.
- Auch aus der Inbox heraus können Einträge als Gelerntes über Organisationen übertragen werden.

## Bekannte Fehler

- Bei längeren Antworten, die der Chatbot generiert, überschreibt er seine Antwort irgendwann selbst.
- Wenn ein neuer Chat geöffnet wird, könnten während des Ladens Neuigkeiten gestreamt, die von der UI nicht erfasst werden. Dadurch wirkt der Text am Anfang abgehackt.