### PR TITLE
Pausierte Projekte ausschlanken

### DIFF
--- a/components/planning/day/DailyPlanMaybeProject.tsx
+++ b/components/planning/day/DailyPlanMaybeProject.tsx
@@ -1,0 +1,71 @@
+import { Project, useProjectsContext } from "@/api/ContextProjects";
+import { addProjectDayplan } from "@/api/dayplan/add-project-dayplan";
+import { DailyPlan, DailyPlanProject } from "@/api/useDailyPlans";
+import { ButtonPlayPause } from "@/components/ui/button-play-pause";
+import { IconButton } from "@/components/ui/icon-button";
+import { flow, get, identity } from "lodash/fp";
+import { ExternalLink } from "lucide-react";
+import { FC, useEffect, useState } from "react";
+
+interface DailyPlanMaybeProjectProps {
+  dayPlan: DailyPlan;
+  dailyPlanProject: DailyPlanProject;
+  mutateProject: (project: DailyPlanProject, refresh: boolean) => void;
+}
+
+const DailyPlanMaybeProject: FC<DailyPlanMaybeProjectProps> = ({
+  dayPlan,
+  dailyPlanProject,
+  mutateProject,
+}) => {
+  const { getProjectById } = useProjectsContext();
+  const [project, setProject] = useState<Project | undefined>();
+
+  useEffect(() => {
+    flow(
+      identity<DailyPlanProject>,
+      get("projectId"),
+      getProjectById,
+      setProject
+    )(dailyPlanProject);
+  }, [dailyPlanProject, getProjectById]);
+
+  const addProject = (maybe: boolean) =>
+    addProjectDayplan({
+      data: {
+        dayPlanId: dayPlan.id,
+        projectId: dailyPlanProject.projectId,
+        maybe,
+      },
+      options: {
+        mutate: (refresh) =>
+          mutateProject({ ...dailyPlanProject, maybe }, refresh),
+      },
+    });
+
+  return (
+    project && (
+      <div className="space-y-2">
+        <div className="font-semibold">{project.project}</div>
+        <div className="flex flex-wrap gap-1">
+          <ButtonPlayPause
+            state={dailyPlanProject.maybe ? "PAUSE" : "PLAY"}
+            className="h-7 p-1"
+            onClick={() => addProject(!dailyPlanProject.maybe)}
+          />
+
+          <IconButton
+            tooltip="Details"
+            label="Details"
+            className="w-24 h-7 p-1"
+            onClick={() => window.open(`/projects/${project.id}`, "_blank")}
+          >
+            <ExternalLink className="w-4 h-4" />
+          </IconButton>
+        </div>
+      </div>
+    )
+  );
+};
+
+export default DailyPlanMaybeProject;

--- a/components/today/DailyPlan.tsx
+++ b/components/today/DailyPlan.tsx
@@ -9,6 +9,7 @@ import { setProjectList } from "@/helpers/today";
 import { FC, useEffect, useState } from "react";
 import ShowHideSwitch from "../ui-elements/ShowHideSwitch";
 import DayPlanInformation from "./DayPlanInformation";
+import DayPlanMaybeProjects from "./DayPlanMaybeProjects";
 import DayPlanProjects from "./DayPlanProjects";
 import ShowNoTodos from "./ShowNoTodos";
 
@@ -74,10 +75,9 @@ const DailyPlanComponent: FC<DailyPlanComponentProps> = ({
         />
 
         {showMaybe && (
-          <DayPlanProjects
+          <DayPlanMaybeProjects
             dayPlan={dailyPlan}
             dayPlanProjects={projectsMaybe}
-            mutateTodo={mutateTodo}
             mutateProject={mutateProject}
           />
         )}

--- a/components/today/DayPlanMaybeProjects.tsx
+++ b/components/today/DayPlanMaybeProjects.tsx
@@ -1,0 +1,23 @@
+import { DailyPlan, DailyPlanProject } from "@/api/useDailyPlans";
+import { FC } from "react";
+import DailyPlanMaybeProject from "../planning/day/DailyPlanMaybeProject";
+
+interface DayPlanMaybeProjectsProps {
+  dayPlan: DailyPlan;
+  dayPlanProjects: DailyPlanProject[] | undefined;
+  mutateProject: (project: DailyPlanProject, refresh: boolean) => void;
+}
+
+const DayPlanMaybeProjects: FC<DayPlanMaybeProjectsProps> = ({
+  dayPlan,
+  dayPlanProjects,
+  mutateProject,
+}) =>
+  dayPlanProjects?.map((p) => (
+    <DailyPlanMaybeProject
+      key={p.recordId}
+      {...{ dayPlan, dailyPlanProject: p, mutateProject }}
+    />
+  ));
+
+export default DayPlanMaybeProjects;

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,12 +1,6 @@
-# Symbole für Aufgaben optimieren (Version :VERSION)
+# Pausierte Projekte ausschlanken (Version :VERSION)
 
-- Die Symbole für Projekte in der Tagesaufgabenliste sind nun eindeutiger und mit Beschriftungen unterstützt.
-- Die Symbole für Aufgaben in der Tages-, Besprechungs- und Projektaufgabenliste sind nun eindeutiger und mit Beschriftungen unterstützt.
-- In Projekten und in Besprechungen können Aufgaben nun auch in der Aufgabenliste direkt abgeschlossen werden.
-
-## Fehlerbehebungen
-
-- In Besprechungen werden wieder die vereinbarten Aufgaben angezeigt.
+- Pausierte Projekte sind ausgeschlankt, so dass sie in der täglichen Aufgabenliste besser zu unterscheiden sind von den Projekten im Fokus.
 
 ## Bekannte Fehler
 


### PR DESCRIPTION
- Pausierte Projekte sind ausgeschlankt, so dass sie in der täglichen Aufgabenliste besser zu unterscheiden sind von den Projekten im Fokus.

## Bekannte Fehler

- Bei längeren Antworten, die der Chatbot generiert, überschreibt er seine Antwort irgendwann selbst.
- Wenn ein neuer Chat geöffnet wird, könnten während des Ladens Neuigkeiten gestreamt, die von der UI nicht erfasst werden. Dadurch wirkt der Text am Anfang abgehackt.