### PR TITLE
Optionale Schritte in der Wochenplanung

### DIFF
--- a/amplify/data/planning-schema.ts
+++ b/amplify/data/planning-schema.ts
@@ -19,6 +19,9 @@ const planningSchema = {
       startDate: a.date().required(),
       status: a.ref("PlanningStatus").required(),
       projects: a.hasMany("WeeklyPlanProject", "weekPlanId"),
+      inboxSkipped: a.boolean(),
+      financialUpdateSkipped: a.boolean(),
+      crmUpdateSkipped: a.boolean(),
     })
     .secondaryIndexes((index) => [index("status")])
     .authorization((allow) => [allow.owner()]),

--- a/api/useWeekPlan.tsx
+++ b/api/useWeekPlan.tsx
@@ -16,6 +16,9 @@ export type WeeklyPlan = {
   startDate: Date;
   status: TWeekPlanStatus;
   projectIds: string[];
+  inboxSkipped: boolean;
+  financialUpdateSkipped: boolean;
+  crmUpdateSkipped: boolean;
 };
 
 const selectionSet = [
@@ -23,6 +26,9 @@ const selectionSet = [
   "startDate",
   "status",
   "projects.projectId",
+  "inboxSkipped",
+  "financialUpdateSkipped",
+  "crmUpdateSkipped",
 ] as const;
 
 type WeeklyPlanData = SelectionSet<
@@ -35,11 +41,17 @@ const mapWeekPlan: (data: WeeklyPlanData) => WeeklyPlan = ({
   startDate,
   status,
   projects,
+  inboxSkipped,
+  financialUpdateSkipped,
+  crmUpdateSkipped,
 }) => ({
   id,
   startDate: new Date(startDate),
   status,
   projectIds: projects.map(({ projectId }) => projectId),
+  inboxSkipped: !!inboxSkipped,
+  financialUpdateSkipped: !!financialUpdateSkipped,
+  crmUpdateSkipped: !!crmUpdateSkipped,
 });
 
 const fetchWeekPlans = async () => {
@@ -71,7 +83,15 @@ const useWeekPlan = () => {
 
   const createWeekPlan = async (startDate: Date) => {
     const updated: WeeklyPlan[] = [
-      { id: crypto.randomUUID(), startDate, status: "WIP", projectIds: [] },
+      {
+        id: crypto.randomUUID(),
+        startDate,
+        status: "WIP",
+        projectIds: [],
+        inboxSkipped: false,
+        financialUpdateSkipped: false,
+        crmUpdateSkipped: false,
+      },
     ];
     mutate(updated, false);
     if (weekPlans && weekPlans.length > 0) {
@@ -197,6 +217,12 @@ const useWeekPlan = () => {
     makeProjectDecision,
     isLoading,
     error,
+    mutate: (weekPlan: WeeklyPlan | undefined, update?: boolean) =>
+      weekPlan &&
+      mutate(
+        weekPlans?.map((p) => (p.id !== weekPlan?.id ? p : weekPlan)),
+        update
+      ),
   };
 };
 

--- a/components/learnings/LearningComponent.tsx
+++ b/components/learnings/LearningComponent.tsx
@@ -93,7 +93,7 @@ const LearningComponent: FC<LearningComponentProps> = ({
       <div className={cn(!editable && "-mx-2")}>
         <NotesWriter
           readonly={!editable}
-          placeholder="Document what you've learned about the person…"
+          placeholder="Document what you've learned…"
           notes={learning.learning}
           saveNotes={onChange}
         />

--- a/components/planning/week/PlanWeekAction.tsx
+++ b/components/planning/week/PlanWeekAction.tsx
@@ -1,13 +1,43 @@
-import { FC } from "react";
+import { Button } from "@/components/ui/button";
+import { Loader2 } from "lucide-react";
+import { FC, useState } from "react";
 
 type PlanWeekActionProps = {
   label: string;
+  skip?: () => void;
 };
 
-const PlanWeekAction: FC<PlanWeekActionProps> = ({ label }) => (
-  <div className="border-2 border-[--context-color] rounded-md flex justify-center p-1 font-semibold">
-    Next Action: {label}
-  </div>
-);
+const PlanWeekAction: FC<PlanWeekActionProps> = ({ label, skip }) => {
+  const [skipping, setSkipping] = useState(false);
+
+  const handleSkip = () => {
+    setSkipping(true);
+    skip?.();
+  };
+
+  return (
+    <div className="border-2 border-[--context-color] rounded-md flex justify-center p-1 font-semibold flex-col items-center text-center">
+      <span>Next Action: {label}</span>
+      {skip && (
+        <Button
+          size="sm"
+          variant="link"
+          onClick={handleSkip}
+          className="text-muted-foreground hover:text-primary"
+          disabled={skipping}
+        >
+          {!skipping ? (
+            "Skip"
+          ) : (
+            <div className="flex flex-row gap-1">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Skipping
+            </div>
+          )}
+        </Button>
+      )}
+    </div>
+  );
+};
 
 export default PlanWeekAction;

--- a/components/planning/week/ProcessCrmUpdates.tsx
+++ b/components/planning/week/ProcessCrmUpdates.tsx
@@ -5,11 +5,18 @@ import { FC } from "react";
 
 interface ProcessCrmUpdatesProps {
   mutateSfdc: ReturnType<typeof useMrrLatestUpload>["mutateSfdc"];
+  skipCrmUpdate?: () => void;
 }
 
-const ProcessCrmUpdates: FC<ProcessCrmUpdatesProps> = ({ mutateSfdc }) => (
+const ProcessCrmUpdates: FC<ProcessCrmUpdatesProps> = ({
+  mutateSfdc,
+  skipCrmUpdate,
+}) => (
   <>
-    <PlanWeekAction label="Upload Salesforce Opportunities" />
+    <PlanWeekAction
+      label="Upload Salesforce Opportunities"
+      skip={skipCrmUpdate}
+    />
     <ImportProjectData reloader={mutateSfdc} />
   </>
 );

--- a/components/planning/week/ProcessFinancialUpdates.tsx
+++ b/components/planning/week/ProcessFinancialUpdates.tsx
@@ -7,13 +7,18 @@ import { FC } from "react";
 
 interface ProcessFinancialUpdatesProps {
   mutateMrr: ReturnType<typeof useMrrLatestUpload>["mutateMrr"];
+  skipFinancialUpdate?: () => void;
 }
 
 const ProcessFinancialUpdates: FC<ProcessFinancialUpdatesProps> = ({
   mutateMrr,
+  skipFinancialUpdate,
 }) => (
   <>
-    <PlanWeekAction label="Upload Customer Financials" />
+    <PlanWeekAction
+      label="Upload Customer Financials"
+      skip={skipFinancialUpdate}
+    />
     <MrrFilterProvider>
       <Accordion type="single" collapsible>
         <InstructionsUploadMrr reloader={mutateMrr} />

--- a/components/planning/week/ProcessInbox.tsx
+++ b/components/planning/week/ProcessInbox.tsx
@@ -1,9 +1,14 @@
 import ProcessInboxItem from "@/components/inbox/ProcessInboxItem";
 import PlanWeekAction from "@/components/planning/week/PlanWeekAction";
+import { FC } from "react";
 
-const ProcessInbox = () => (
+interface ProcessInboxProps {
+  skipInbox?: () => void;
+}
+
+const ProcessInbox: FC<ProcessInboxProps> = ({ skipInbox }) => (
   <>
-    <PlanWeekAction label="Process Inbox Items" />
+    <PlanWeekAction label="Process Inbox Items" skip={skipInbox} />
     <ProcessInboxItem />
   </>
 );

--- a/components/ui-elements/notes-writer/NotesWriter.tsx
+++ b/components/ui-elements/notes-writer/NotesWriter.tsx
@@ -66,7 +66,8 @@ const NotesWriter: FC<NotesWriterProps> = ({
         },
         attributes: {
           class: cn(
-            "prose w-full max-w-full text-notesEditor rounded-md p-2 bg-inherit transition duration-1000 ease",
+            "prose w-full max-w-full text-notesEditor bg-inherit transition duration-1000 ease p-2",
+            !readonly && "rounded-md border pt-16",
             showSaveStatus &&
               !readonly &&
               !isUpToDate(notes, editor.getJSON()) &&

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -1,6 +1,8 @@
-# Notizen Menü überall zeigen (Version :VERSION)
+# Optionale Schritte in der Wochenplanung (Version :VERSION)
 
-- Das Menü zum Formatieren für Notizen wird nun überall angezeigt.
+- Das Leeren der Inbox kann nun in der Wochenplanung übersprungen werden.
+- Das Aktualisieren der Finanzdaten kann nun in der Wochenplanung übersprungen werden.
+- Das Aktualisieren der CRM Projekte kann nun in der Wochenplanung übersprungen werden.
 
 ## Bekannte Fehler
 
@@ -8,6 +10,8 @@
 - Wenn ein neuer Chat geöffnet wird, könnten während des Ladens Neuigkeiten gestreamt, die von der UI nicht erfasst werden. Dadurch wirkt der Text am Anfang abgehackt.
 
 ## In Arbeit
+
+- Bei Gelerntem zu Kunden und Personen erscheint die erste Zeile unter der Menüleiste.
 
 ## Geplant
 

--- a/docs/releases/next.md
+++ b/docs/releases/next.md
@@ -4,14 +4,16 @@
 - Das Aktualisieren der Finanzdaten kann nun in der Wochenplanung übersprungen werden.
 - Das Aktualisieren der CRM Projekte kann nun in der Wochenplanung übersprungen werden.
 
+## Fehlerbehebungen
+
+- Bei Gelerntem zu Kunden und Personen erscheint die erste Zeile nun unter der Menüleiste und ist nicht mehr von dieser abgedeckt.
+
 ## Bekannte Fehler
 
 - Bei längeren Antworten, die der Chatbot generiert, überschreibt er seine Antwort irgendwann selbst.
 - Wenn ein neuer Chat geöffnet wird, könnten während des Ladens Neuigkeiten gestreamt, die von der UI nicht erfasst werden. Dadurch wirkt der Text am Anfang abgehackt.
 
 ## In Arbeit
-
-- Bei Gelerntem zu Kunden und Personen erscheint die erste Zeile unter der Menüleiste.
 
 ## Geplant
 

--- a/pages/planweek.tsx
+++ b/pages/planweek.tsx
@@ -9,15 +9,25 @@ import {
 } from "@/components/planning/useWeekPlanContext";
 import PlanWeekForm from "@/components/planning/week/PlanWeekForm";
 import ProcessCrmUpdates from "@/components/planning/week/ProcessCrmUpdates";
+import ProcessFinancialUpdates from "@/components/planning/week/ProcessFinancialUpdates";
 import ProcessInbox from "@/components/planning/week/ProcessInbox";
 import ProcessProjects from "@/components/planning/week/ProcessProjects";
 import { useContextContext } from "@/contexts/ContextContext";
 
 const WeeklyPlanningPage = () => {
   const { context } = useContextContext();
-  const { error } = useWeekPlanContext();
+  const {
+    error,
+    inboxSkipped,
+    financialUpdateSkipped,
+    crmUpdateSkipped,
+    skipCrmUpdate,
+    skipFinancialUpdate,
+    skipInbox,
+  } = useWeekPlanContext();
   const { inbox } = useInbox();
-  const { sfdcUploadTooOld, mutateSfdc } = useMrrLatestUpload();
+  const { sfdcUploadTooOld, mutateSfdc, mrrUploadTooOld, mutateMrr } =
+    useMrrLatestUpload();
 
   return (
     <MainLayout title="Weekly Planning" sectionName="Weekly Planning">
@@ -30,10 +40,12 @@ const WeeklyPlanningPage = () => {
           <ContextSwitcher />
         </div>
 
-        {inbox && inbox.length > 0 ? (
-          <ProcessInbox />
-        ) : context === "work" && sfdcUploadTooOld ? (
-          <ProcessCrmUpdates {...{ mutateSfdc }} />
+        {!inboxSkipped && inbox && inbox.length > 0 ? (
+          <ProcessInbox {...{ skipInbox }} />
+        ) : context === "work" && !financialUpdateSkipped && mrrUploadTooOld ? (
+          <ProcessFinancialUpdates {...{ mutateMrr, skipFinancialUpdate }} />
+        ) : context === "work" && !crmUpdateSkipped && sfdcUploadTooOld ? (
+          <ProcessCrmUpdates {...{ mutateSfdc, skipCrmUpdate }} />
         ) : (
           <ProcessProjects />
         )}
@@ -43,6 +55,3 @@ const WeeklyPlanningPage = () => {
 };
 
 export default withWeekPlan(WeeklyPlanningPage);
-
-// ) : context === "work" && mrrUploadTooOld ? (
-//   <ProcessFinancialUpdates {...{ mutateMrr }} />


### PR DESCRIPTION
- Das Leeren der Inbox kann nun in der Wochenplanung übersprungen werden.
- Das Aktualisieren der Finanzdaten kann nun in der Wochenplanung übersprungen werden.
- Das Aktualisieren der CRM Projekte kann nun in der Wochenplanung übersprungen werden.

## Fehlerbehebungen

- Bei Gelerntem zu Kunden und Personen erscheint die erste Zeile nun unter der Menüleiste und ist nicht mehr von dieser abgedeckt.

## Bekannte Fehler

- Bei längeren Antworten, die der Chatbot generiert, überschreibt er seine Antwort irgendwann selbst.
- Wenn ein neuer Chat geöffnet wird, könnten während des Ladens Neuigkeiten gestreamt, die von der UI nicht erfasst werden. Dadurch wirkt der Text am Anfang abgehackt.
