### PR TITLE
fix(exports): show toast for one-time exports after S3 migration

### DIFF
--- a/api/ContextExports.tsx
+++ b/api/ContextExports.tsx
@@ -30,15 +30,16 @@ export const ExportsProvider: FC<ExportsProviderProps> = ({ children }) => {
               description: `Export for ${data.itemName} failed: ${data.error}`,
               variant: "destructive",
             });
-          } else if (data.result) {
+          } else if (data.s3Key) {
             // Export succeeded - show action buttons
             toast({
               title: "Export ready",
               description: `Export for ${data.itemName} is ready`,
+              duration: 30000,
               action: (
                 <ExportActions
                   taskId={data.id}
-                  result={data.result}
+                  s3Key={data.s3Key}
                   itemName={data.itemName || ""}
                   dataSource={data.dataSource || ""}
                   variant="outline"

--- a/components/exports/ExportActions.tsx
+++ b/components/exports/ExportActions.tsx
@@ -1,5 +1,6 @@
-import { FC } from "react";
+import { FC, useState } from "react";
 import { Download, Copy } from "lucide-react";
+import { downloadData } from "aws-amplify/storage";
 import { Button } from "@/components/ui/button";
 import {
   copyToClipboard,
@@ -10,7 +11,7 @@ import { useExports } from "@/api/useExports";
 
 interface ExportActionsProps {
   taskId: string;
-  result: string;
+  s3Key: string;
   itemName: string;
   dataSource: string;
   variant?: "default" | "ghost" | "outline";
@@ -20,7 +21,7 @@ interface ExportActionsProps {
 
 export const ExportActions: FC<ExportActionsProps> = ({
   taskId,
-  result,
+  s3Key,
   itemName,
   dataSource,
   variant = "default",
@@ -28,27 +29,55 @@ export const ExportActions: FC<ExportActionsProps> = ({
   showLabels = true,
 }) => {
   const { markExportCompleted } = useExports();
+  const [isBusy, setIsBusy] = useState(false);
 
-  const handleCopy = async () => {
-    const success = await copyToClipboard(result, itemName);
-    if (success) {
+  const fetchContent = async (): Promise<string | null> => {
+    try {
+      const { body } = await downloadData({ path: s3Key }).result;
+      return await body.text();
+    } catch (error) {
+      console.error("Failed to download export from S3:", error);
       toast({
-        title: "Copied to clipboard",
-        description: "Export data copied successfully",
-      });
-      await markExportCompleted(taskId);
-    } else {
-      toast({
-        title: "Copy failed",
-        description: "Failed to copy to clipboard",
+        title: "Download failed",
+        description: "Could not fetch export from S3",
         variant: "destructive",
       });
+      return null;
+    }
+  };
+
+  const handleCopy = async () => {
+    setIsBusy(true);
+    try {
+      const content = await fetchContent();
+      if (!content) return;
+
+      const success = await copyToClipboard(content, itemName);
+      if (success) {
+        toast({
+          title: "Copied to clipboard",
+          description: "Export data copied successfully",
+        });
+        await markExportCompleted(taskId);
+      } else {
+        toast({
+          title: "Copy failed",
+          description: "Failed to copy to clipboard",
+          variant: "destructive",
+        });
+      }
+    } finally {
+      setIsBusy(false);
     }
   };
 
   const handleDownload = async () => {
+    setIsBusy(true);
     try {
-      downloadMarkdown(result, itemName, dataSource);
+      const content = await fetchContent();
+      if (!content) return;
+
+      downloadMarkdown(content, itemName, dataSource);
       toast({
         title: "Download started",
         description: "Export file is downloading",
@@ -60,12 +89,19 @@ export const ExportActions: FC<ExportActionsProps> = ({
         description: `Failed to download export: ${error instanceof Error ? error.message : JSON.stringify(error)}`,
         variant: "destructive",
       });
+    } finally {
+      setIsBusy(false);
     }
   };
 
   return (
     <div className="flex gap-2">
-      <Button variant={variant} size={size} onClick={handleDownload}>
+      <Button
+        variant={variant}
+        size={size}
+        onClick={handleDownload}
+        disabled={isBusy}
+      >
         <Download className={showLabels ? "mr-2 size-4" : "size-4"} />
         {showLabels && "Download"}
       </Button>
@@ -73,6 +109,7 @@ export const ExportActions: FC<ExportActionsProps> = ({
         variant={variant === "default" ? "outline" : variant}
         size={size}
         onClick={handleCopy}
+        disabled={isBusy}
       >
         <Copy className={showLabels ? "mr-2 size-4" : "size-4"} />
         {showLabels && "Copy"}

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "test:ui": "vitest --ui",
     "test:run": "vitest run",
     "signin:code-assistant": "aws sso login --profile nxsflow-staging",
-    "sandbox": "npx ampx sandbox --profile impulso",
+    "sandbox": "npx ampx sandbox --profile impulso --once",
     "sandbox:debug": "npx ampx sandbox --profile impulso --debug",
     "sandbox:logs": "npx ampx sandbox --profile impulso --stream-function-logs",
     "import-data-dev": "cd scripts && node start-import -env dev",


### PR DESCRIPTION
## Summary
- The S3 migration (9306c68) moved one-time export payloads from DynamoDB `result` to `s3Key`, but `ContextExports.tsx` and `ExportActions` still gated on `result` — so the "Export ready" toast never fired after a one-time export completed.
- `ContextExports.tsx` now gates the toast on `data.s3Key`, forwards the key to `ExportActions`, and keeps the toast visible for 30 s so the user can actually reach the Download/Copy buttons.
- `ExportActions` now accepts `s3Key` and pulls the markdown from S3 on demand (same path `ExportHistoryItem` already uses), with a busy state guarding double-clicks.
- Minor: `package.json` adds `--once` to the `sandbox` script for non-interactive deploys.

Out of scope (separate work):
- Recurring exports still don't notify (status `COMPLETED` ≠ frontend's `GENERATED`, plus subscription only runs when a tab is open).
- "Empty" exports (date window with no activity) produce a 3-byte file — UX could explicitly say "no data in this window".

## Test plan
- [x] Trigger a one-time export with a date range that has activity — toast appears and stays ~30 s
- [x] Click Download in the toast — file downloads from S3, contains expected markdown
- [x] Click Copy in the toast — clipboard receives the markdown
- [ ] Verify the Export History page (`/profile/exports`) Download/Copy still work (no regression — they use their own S3 fetch path)
- [ ] Verify a failed export still shows the destructive toast