### PR TITLE
feat(exports): add meeting export

### DIFF
--- a/amplify/data/ai-schema.ts
+++ b/amplify/data/ai-schema.ts
@@ -86,7 +86,7 @@ const aiSchema = {
     .authorization((allow) => [allow.authenticated()]),
 
   // ------- Enums
-  ExportTaskDataSource: a.enum(["account", "project"]),
+  ExportTaskDataSource: a.enum(["account", "project", "meeting"]),
   ExportStatus: a.enum(["CREATED", "GENERATED", "COMPLETED"]),
   RecurrenceFrequency: a.enum(["daily", "weekly", "monthly"]),
   RecurringExportStatus: a.enum(["active", "inactive"]),

--- a/amplify/functions/process-export-tasks/fetching/process-export.ts
+++ b/amplify/functions/process-export-tasks/fetching/process-export.ts
@@ -1,4 +1,9 @@
-import { ExportTask, getAccountMd, getProjectMd } from "../helpers";
+import {
+  ExportTask,
+  getAccountMd,
+  getMeetingMd,
+  getProjectMd,
+} from "../helpers";
 
 export const processExport = async (task: ExportTask): Promise<string> => {
   console.log("Processing export", task);
@@ -10,6 +15,8 @@ export const processExport = async (task: ExportTask): Promise<string> => {
       return await getAccountMd(task);
     case "project":
       return await getProjectMd(task);
+    case "meeting":
+      return await getMeetingMd(task);
     default:
       throw new Error(`Unknown data source: ${task.dataSource}`);
   }

--- a/amplify/functions/process-export-tasks/handler.ts
+++ b/amplify/functions/process-export-tasks/handler.ts
@@ -3,6 +3,14 @@ import { processExport } from "./fetching";
 import { getItemRaw, loadTaskRecord, SkipRecordError } from "./helpers";
 import { handleOneTimeExport } from "./helpers/handle-one-time-export";
 import { handleRecurringExport } from "./helpers/handle-recurring-export";
+import { markTaskAsFailed } from "./helpers/update-task";
+
+const errorMessage = (error: unknown): string =>
+  error instanceof Error
+    ? error.message
+    : typeof error === "string"
+      ? error
+      : JSON.stringify(error);
 
 export const handler: DynamoDBStreamHandler = async (event) => {
   console.log("Processing DynamoDB Stream event", {
@@ -10,8 +18,10 @@ export const handler: DynamoDBStreamHandler = async (event) => {
   });
 
   for (const record of event.Records) {
+    let taskId: string | undefined;
     try {
       const task = loadTaskRecord(record);
+      taskId = task.id;
 
       // For recurring tasks, AppSync strips `::username` off the owner field
       // on IAM writes, so `task.owner` is the single sub. The data tables
@@ -56,6 +66,9 @@ export const handler: DynamoDBStreamHandler = async (event) => {
         continue;
       }
       console.error("Error processing export", error);
+      if (taskId) {
+        await markTaskAsFailed(taskId, errorMessage(error));
+      }
     }
   }
 };

--- a/amplify/functions/process-export-tasks/helpers/activities.ts
+++ b/amplify/functions/process-export-tasks/helpers/activities.ts
@@ -40,7 +40,7 @@ type MeetingInfo = {
   participantIds: string[];
 };
 
-type BlockRecord = {
+export type BlockRecord = {
   id: string;
   type?: string;
   content?: JSONContent | string | null;
@@ -82,7 +82,7 @@ const isCurrentEmployment = (
   return true;
 };
 
-const fetchCurrentEmployment = async (
+export const fetchCurrentEmployment = async (
   personId: string,
   opts: OwnerOpts
 ): Promise<Employment | null> => {
@@ -111,7 +111,7 @@ const fetchCurrentEmployment = async (
   };
 };
 
-const renderParticipant = (
+export const renderParticipant = (
   name: string,
   employment: Employment | null
 ): string => {
@@ -232,7 +232,7 @@ const resolveMentions = async (
 
 /* =========================== blocks fetch ========================== */
 
-const fetchBlocks = async (
+export const fetchBlocks = async (
   activity: ActivityRecord,
   opts: OwnerOpts
 ): Promise<BlockRecord[]> => {
@@ -332,7 +332,7 @@ const renderBlock = (block: BlockRecord): string => {
   return getMarkdown(parseContent(block.content) as JSONContent);
 };
 
-const renderBlocks = (blocks: BlockRecord[] | undefined): string => {
+export const renderBlocks = (blocks: BlockRecord[] | undefined): string => {
   const parts: string[] = [];
   let orderedCount = 0;
   let prevType: string | undefined;

--- a/amplify/functions/process-export-tasks/helpers/index.ts
+++ b/amplify/functions/process-export-tasks/helpers/index.ts
@@ -6,6 +6,7 @@ export * from "./get-client";
 export * from "./handle-recurring-export";
 export * from "./load-task-record";
 export * from "./markdown";
+export * from "./meetings";
 export * from "./projects";
 export * from "./s3-upload";
 export * from "./tiptap-doc";

--- a/amplify/functions/process-export-tasks/helpers/meetings.ts
+++ b/amplify/functions/process-export-tasks/helpers/meetings.ts
@@ -1,0 +1,226 @@
+import {
+  fetchBlocks,
+  fetchCurrentEmployment,
+  renderBlocks,
+  renderParticipant,
+  type ActivityRecord,
+  type BlockRecord,
+} from "./activities";
+import { batchGetItems, getItem, queryByIndex } from "./dynamodb";
+import type { ExportTask } from "./load-task-record";
+
+type OwnerOpts = { owner: string };
+
+type MeetingRecord = {
+  id: string;
+  topic?: string | null;
+  meetingOn?: string | null;
+  createdAt?: string | null;
+  [k: string]: unknown;
+};
+
+type ProjectRef = {
+  projectName: string;
+  accountNames: string[];
+};
+
+type EnrichedActivity = {
+  activity: ActivityRecord;
+  blocks: BlockRecord[];
+  projects: ProjectRef[];
+};
+
+/* ============================ formatting =========================== */
+
+const TIMEZONE = "Europe/Berlin";
+
+/**
+ * Format the meeting datetime as `YYYY-MM-DD HH:mm CET` in Europe/Berlin.
+ * The literal "CET" suffix is used (technically CEST in summer, but the user
+ * asked for "CET" as the label).
+ */
+const formatMeetingDateTime = (iso: string | null | undefined): string => {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const parts = new Intl.DateTimeFormat("en-CA", {
+    timeZone: TIMEZONE,
+    year: "numeric",
+    month: "2-digit",
+    day: "2-digit",
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  }).formatToParts(d);
+  const get = (type: string) => parts.find((p) => p.type === type)?.value ?? "";
+  return `${get("year")}-${get("month")}-${get("day")} ${get("hour")}:${get("minute")} CET`;
+};
+
+/* ============================ fetching ============================= */
+
+const fetchParticipants = async (
+  meetingId: string,
+  opts: OwnerOpts
+): Promise<string[]> => {
+  const junctions = await queryByIndex(
+    "MeetingParticipant",
+    "gsi-Meeting.participants",
+    "meetingId",
+    meetingId,
+    opts
+  );
+  const personIds = junctions
+    .map((j) => (j as { personId?: string }).personId)
+    .filter((id): id is string => !!id);
+  const personMap = await batchGetItems<{ id: string; name?: string }>(
+    "Person",
+    personIds,
+    opts
+  );
+  const people = personIds
+    .map((id) => personMap.get(id))
+    .filter((p): p is { id: string; name: string } => !!p && !!p.name);
+  const employments = await Promise.all(
+    people.map((p) => fetchCurrentEmployment(p.id, opts))
+  );
+  return people.map((p, i) => renderParticipant(p.name, employments[i]));
+};
+
+const fetchActivitiesForMeeting = async (
+  meetingId: string,
+  opts: OwnerOpts
+): Promise<ActivityRecord[]> => {
+  return queryByIndex<ActivityRecord>(
+    "Activity",
+    "gsi-Meeting.activities",
+    "meetingActivitiesId",
+    meetingId,
+    opts
+  );
+};
+
+const fetchProjectsForActivity = async (
+  activityId: string,
+  opts: OwnerOpts
+): Promise<ProjectRef[]> => {
+  const projectJunctions = await queryByIndex(
+    "ProjectActivity",
+    "gsi-Activity.forProjects",
+    "activityId",
+    activityId,
+    opts
+  );
+  const projectIds = projectJunctions
+    .map((j) => (j as { projectsId?: string }).projectsId)
+    .filter((id): id is string => !!id);
+  if (!projectIds.length) return [];
+
+  const projectMap = await batchGetItems<{ id: string; project?: string }>(
+    "Projects",
+    projectIds,
+    opts
+  );
+
+  // For each project, fetch its linked accounts via the AccountProjects junction.
+  const refs = await Promise.all(
+    projectIds.map(async (projectId): Promise<ProjectRef | null> => {
+      const project = projectMap.get(projectId);
+      if (!project?.project) return null;
+      const accountJunctions = await queryByIndex(
+        "AccountProjects",
+        "accountProjectsByProjectsId",
+        "projectsId",
+        projectId,
+        opts
+      );
+      const accountIds = accountJunctions
+        .map((j) => (j as { accountId?: string }).accountId)
+        .filter((id): id is string => !!id);
+      const accountMap = await batchGetItems<{ id: string; name?: string }>(
+        "Account",
+        accountIds,
+        opts
+      );
+      const accountNames = accountIds
+        .map((id) => accountMap.get(id)?.name)
+        .filter((n): n is string => !!n);
+      return { projectName: project.project, accountNames };
+    })
+  );
+  return refs.filter((r): r is ProjectRef => !!r);
+};
+
+/* ============================ rendering ============================ */
+
+const renderProjects = (projects: ProjectRef[]): string =>
+  projects
+    .map((p) =>
+      p.accountNames.length
+        ? `${p.projectName} (${p.accountNames.join(", ")})`
+        : p.projectName
+    )
+    .join(", ");
+
+const renderActivityBlock = (entry: EnrichedActivity): string => {
+  const topic = renderProjects(entry.projects);
+  const body = renderBlocks(entry.blocks);
+  const head = `## Topic: ${topic}`;
+  return body ? `${head}\n\n${body}` : head;
+};
+
+const pickActivityDate = (a: ActivityRecord): string =>
+  a.finishedOn || a.createdAt || a.updatedAt || "";
+
+/* =========================== entry point =========================== */
+
+export const getMeetingMd = async (task: ExportTask): Promise<string> => {
+  const meeting = await getItem<MeetingRecord>("Meeting", task.itemId, {
+    owner: task.owner,
+  });
+  if (!meeting) {
+    console.warn(
+      `[export] meeting ${task.itemId} not found or not owned by ${task.owner}`
+    );
+    return "";
+  }
+
+  const [participants, activities] = await Promise.all([
+    fetchParticipants(meeting.id, { owner: task.owner }),
+    fetchActivitiesForMeeting(meeting.id, { owner: task.owner }),
+  ]);
+
+  const enriched = await Promise.all(
+    activities.map(async (activity): Promise<EnrichedActivity> => {
+      const [blocks, projects] = await Promise.all([
+        fetchBlocks(activity, { owner: task.owner }),
+        fetchProjectsForActivity(activity.id, { owner: task.owner }),
+      ]);
+      return { activity, blocks, projects };
+    })
+  );
+
+  // Drop activities that aren't linked to any project (per spec).
+  const withProjects = enriched
+    .filter((e) => e.projects.length > 0)
+    .sort((a, b) => {
+      const da = pickActivityDate(a.activity);
+      const db = pickActivityDate(b.activity);
+      return da < db ? -1 : da > db ? 1 : 0;
+    });
+
+  const dateTime = formatMeetingDateTime(meeting.meetingOn || meeting.createdAt);
+  const title = meeting.topic?.trim() || "Untitled meeting";
+  const heading = dateTime ? `# ${dateTime} - ${title}` : `# ${title}`;
+
+  const sections: string[] = [heading];
+  if (participants.length) {
+    sections.push(
+      ["Participants:", "", ...participants.map((p) => `- ${p}`)].join("\n")
+    );
+  }
+  for (const entry of withProjects) {
+    sections.push(renderActivityBlock(entry));
+  }
+
+  return `${sections.join("\n\n")}\n`;
+};

--- a/amplify/functions/process-export-tasks/helpers/update-task.ts
+++ b/amplify/functions/process-export-tasks/helpers/update-task.ts
@@ -34,3 +34,30 @@ export const updateTaskStatus = async (
   if (!data)
     throw new Error(`Failed updating task with ID ${taskId} to ${status}`);
 };
+
+/**
+ * Mark a task as failed so the frontend subscription fires the destructive
+ * "Export failed" toast. Sets status to GENERATED (the terminal-for-one-time
+ * state the listener watches) with a non-empty `error`. Swallows mutation
+ * errors — this is the error path, we don't want to mask the original failure.
+ */
+export const markTaskAsFailed = async (
+  taskId: string,
+  error: string
+): Promise<void> => {
+  console.log("Marking task as failed", { taskId, error });
+  try {
+    await client.graphql({
+      query: updateExportTask,
+      variables: {
+        input: {
+          id: taskId,
+          status: ExportStatus.GENERATED,
+          error,
+        },
+      },
+    });
+  } catch (mutationError) {
+    console.error("Failed to mark task as failed", { taskId, mutationError });
+  }
+};

--- a/components/exports/MeetingExportButton.tsx
+++ b/components/exports/MeetingExportButton.tsx
@@ -1,0 +1,86 @@
+import { FC, useState } from "react";
+import { Download, Loader2 } from "lucide-react";
+import { generateClient } from "aws-amplify/data";
+import { fetchAuthSession } from "aws-amplify/auth";
+import type { Schema } from "@/amplify/data/resource";
+import { Button } from "@/components/ui/button";
+import { toast } from "@/components/ui/use-toast";
+import { handleApiErrors } from "@/api/globals";
+
+const client = generateClient<Schema>();
+
+interface MeetingExportButtonProps {
+  meetingId: string;
+  meetingTopic: string | null | undefined;
+  meetingOn: Date | string | null | undefined;
+}
+
+export const MeetingExportButton: FC<MeetingExportButtonProps> = ({
+  meetingId,
+  meetingTopic,
+  meetingOn,
+}) => {
+  const [isCreating, setIsCreating] = useState(false);
+
+  const handleClick = async () => {
+    setIsCreating(true);
+    try {
+      const { identityId } = await fetchAuthSession();
+      if (!identityId) {
+        toast({
+          title: "Export failed",
+          description: "Could not resolve your identity. Please sign in again.",
+          variant: "destructive",
+        });
+        return;
+      }
+
+      // The meeting renderer filters by meetingId, not by date — but the
+      // schema requires startDate/endDate, so we anchor both to the meeting's
+      // own date (falling back to now) for traceability in the task record.
+      const anchor = meetingOn ? new Date(meetingOn) : new Date();
+      const iso = anchor.toISOString();
+      const ttl = Math.floor(Date.now() / 1000) + 7 * 24 * 60 * 60;
+
+      const { errors } = await client.models.ExportTask.create({
+        dataSource: "meeting",
+        itemId: meetingId,
+        itemName: meetingTopic || "Meeting",
+        status: "CREATED",
+        startDate: iso,
+        endDate: iso,
+        ttl,
+        identityId,
+      });
+
+      if (errors) {
+        handleApiErrors(errors, "Failed creating export task");
+        return;
+      }
+
+      toast({
+        title: "Export started",
+        description: "You'll be notified when the export is ready.",
+      });
+    } finally {
+      setIsCreating(false);
+    }
+  };
+
+  return (
+    <Button
+      variant="outline"
+      size="sm"
+      className="gap-1"
+      onClick={handleClick}
+      disabled={isCreating}
+    >
+      {isCreating ? (
+        <Loader2 className="w-4 h-4 animate-spin" />
+      ) : (
+        <Download className="w-4 h-4" />
+      )}
+      Export for AI
+    </Button>
+  );
+};

--- a/components/meetings/meeting.tsx
+++ b/components/meetings/meeting.tsx
@@ -16,6 +16,7 @@ import PeopleSelector from "../ui-elements/selectors/people-selector";
 import ProjectSelector from "../ui-elements/selectors/project-selector";
 import { Accordion } from "../ui/accordion";
 import { Button } from "../ui/button";
+import { MeetingExportButton } from "../exports/MeetingExportButton";
 import MeetingActivityList from "./meeting-activity-list";
 import MeetingNextActions from "./meeting-next-actions";
 import MeetingParticipants from "./meeting-participants";
@@ -100,30 +101,39 @@ const MeetingRecord: FC<MeetingRecordProps> = ({
 
   return (
     <div className="space-y-2">
-      <Button
-        onClick={handleUpdateImmediateTasksDone}
-        variant="outline"
-        size="sm"
-        className="gap-1"
-        disabled={savingStatus}
-      >
-        {savingStatus ? (
-          <>
-            <Loader2 className="w-4 h-4 animate-spin" />
-            Saving…
-          </>
-        ) : immediateTasksDone ? (
-          <>
-            <Circle className="w-4 h-4" />
-            Set meeting open
-          </>
-        ) : (
-          <>
-            <CheckCircle2 className="w-4 h-4" />
-            Confirm meeting done
-          </>
+      <div className="flex flex-wrap gap-2">
+        <Button
+          onClick={handleUpdateImmediateTasksDone}
+          variant="outline"
+          size="sm"
+          className="gap-1"
+          disabled={savingStatus}
+        >
+          {savingStatus ? (
+            <>
+              <Loader2 className="w-4 h-4 animate-spin" />
+              Saving…
+            </>
+          ) : immediateTasksDone ? (
+            <>
+              <Circle className="w-4 h-4" />
+              Set meeting open
+            </>
+          ) : (
+            <>
+              <CheckCircle2 className="w-4 h-4" />
+              Confirm meeting done
+            </>
+          )}
+        </Button>
+        {meeting?.id && (
+          <MeetingExportButton
+            meetingId={meeting.id}
+            meetingTopic={meeting.topic}
+            meetingOn={meeting.meetingOn}
+          />
         )}
-      </Button>
+      </div>
 
       {showContext && (
         <div className="space-y-2">


### PR DESCRIPTION
## Summary
- Adds a `meeting` data source to `ExportTask` so a meeting can be exported to markdown with one click — no date-range dialog (the renderer is scoped to a single meeting record, not a window).
- New backend renderer (`helpers/meetings.ts`) producing:
  - `# YYYY-MM-DD HH:mm CET - <topic>` heading (Europe/Berlin, literal "CET" suffix per request).
  - `Participants:` list — each line `- <Name> (<account>, <position>)`. Only PersonAccount rows that are currently active (startDate empty or ≤ today, endDate empty or > today) are used. Multiple active employments are joined with `; `.
  - One `## Topic: <project> (<accounts>)` block per activity, followed by that activity's notes. Activities with no linked project are dropped (per spec).
- New `MeetingExportButton` on the meeting detail page (next to the "Set meeting open/done" toggle) — creates the `ExportTask` directly via the Amplify client and shows the existing "Export started" toast.

### Resilience improvement (bundled because it surfaced during testing)
When the Lambda crashes mid-export, the `ExportTask` used to stay at `status=CREATED` forever — the frontend subscription only listens for `GENERATED`, so the user was left waiting indefinitely with no signal. The handler now calls a new `markTaskAsFailed(taskId, message)` helper on uncaught errors, which writes `status=GENERATED` + `error=<message>` and triggers the existing destructive "Export failed" toast.

### Small internal exports
A few private helpers in `activities.ts` (`fetchCurrentEmployment`, `renderParticipant`, `fetchBlocks`, `renderBlocks`, `BlockRecord` type) are promoted to module exports so `meetings.ts` can reuse them. No behavior change for the project/account export paths.

## Out of scope
- Recurring meeting exports.
- Empty exports (meeting with no project-linked activities) currently produce a header + participants list but no Topic sections. Acceptable; could be improved with a "no project-linked activities in this meeting" note.

## Test plan
- [x] One-click meeting export from a meeting page produces "Export started" toast.
- [x] Lambda completes; markdown lands in S3 under `exports/<identityId>/one-time/<taskId>.md`; "Export ready" toast appears with Download/Copy buttons.
- [x] Output matches the requested format (verified against a real meeting with multiple activities + participants).
- [ ] Force a Lambda failure (e.g. bad meeting ID) → destructive "Export failed" toast appears instead of indefinite wait.
- [ ] Existing project/account exports unaffected (no regression — same code path apart from new exports).