### PR TITLE
fix(editor): improve copy & paste behavior for images and tasks

### DIFF
--- a/components/ui-elements/editors/extensions/s3-images/S3ImageExtension.tsx
+++ b/components/ui-elements/editors/extensions/s3-images/S3ImageExtension.tsx
@@ -1,11 +1,12 @@
 import { toISODateTimeString } from "@/helpers/functional";
 import { cn } from "@/lib/utils";
-import { mergeAttributes } from "@tiptap/core";
+import { Editor, mergeAttributes } from "@tiptap/core";
 import { Node as ProseMirrorNode } from "@tiptap/pm/model";
 import { NodeView } from "@tiptap/pm/view";
 import { Node, NodeViewRenderer } from "@tiptap/react";
 import { getUrl } from "aws-amplify/storage";
 import { isFuture } from "date-fns";
+import { consumeFreshlyPastedBlockId } from "./image-handling";
 
 const assignUrlToDom = async (node: ProseMirrorNode, img: HTMLImageElement) => {
   const stdClasses = "rounded-md border-2 border-solid";
@@ -28,9 +29,25 @@ const assignUrlToDom = async (node: ProseMirrorNode, img: HTMLImageElement) => {
   img.setAttribute("class", stdClasses);
 };
 
-const S3ImageRenderer: NodeViewRenderer = ({ node }): NodeView => {
+const scheduleScrollOnLoad = (
+  node: ProseMirrorNode,
+  img: HTMLImageElement,
+  editor: Editor
+) => {
+  if (!consumeFreshlyPastedBlockId(node.attrs.blockId)) return;
+  const triggerScroll = () => editor.commands.scrollIntoView();
+  if (img.complete && img.naturalHeight > 0) {
+    triggerScroll();
+    return;
+  }
+  img.addEventListener("load", triggerScroll, { once: true });
+  img.addEventListener("error", triggerScroll, { once: true });
+};
+
+const S3ImageRenderer: NodeViewRenderer = ({ node, editor }): NodeView => {
   const dom = document.createElement("img");
   assignUrlToDom(node, dom);
+  scheduleScrollOnLoad(node, dom, editor as Editor);
 
   const selectedClass = "border-[--context-color]";
 

--- a/components/ui-elements/editors/extensions/s3-images/image-handling.ts
+++ b/components/ui-elements/editors/extensions/s3-images/image-handling.ts
@@ -1,21 +1,70 @@
 import { toISODateTimeString } from "@/helpers/functional";
 import { uploadFileToS3 } from "@/helpers/s3/upload-files";
 import { Editor } from "@tiptap/core";
+import { TextSelection } from "@tiptap/pm/state";
 import { EditorView } from "@tiptap/pm/view";
 
+const freshlyPastedBlockIds = new Set<string>();
+
+export const consumeFreshlyPastedBlockId = (blockId: string | null) => {
+  if (!blockId) return false;
+  return freshlyPastedBlockIds.delete(blockId);
+};
+
+export const clearFreshlyPastedBlockIds = () => {
+  freshlyPastedBlockIds.clear();
+};
+
+let userScrollListenersAttached = false;
+const attachUserScrollListeners = () => {
+  if (userScrollListenersAttached) return;
+  if (typeof window === "undefined") return;
+  userScrollListenersAttached = true;
+  const cancel = () => clearFreshlyPastedBlockIds();
+  window.addEventListener("wheel", cancel, { passive: true, capture: true });
+  window.addEventListener("touchmove", cancel, {
+    passive: true,
+    capture: true,
+  });
+};
+
 const dispatchImage = (view: EditorView, url: string, fileName: string) => {
-  const { schema } = view.state;
-  const { tr } = view.state;
-  const pos = view.state.selection.from;
-  tr.insert(
-    pos,
-    schema.nodes.s3image.create({
-      src: url,
-      fileKey: fileName,
-      blockId: crypto.randomUUID(),
-    })
-  );
-  view.dispatch(tr);
+  attachUserScrollListeners();
+  const { schema, selection, tr } = view.state;
+  const blockId = crypto.randomUUID();
+  freshlyPastedBlockIds.add(blockId);
+  const imageNode = schema.nodes.s3image.create({
+    src: url,
+    fileKey: fileName,
+    blockId,
+  });
+
+  const $from = selection.$from;
+  const parent = $from.parent;
+  const isInTextBlock = parent.isTextblock && $from.depth >= 1;
+
+  if (!isInTextBlock) {
+    tr.insert(selection.from, imageNode);
+    view.dispatch(tr.scrollIntoView());
+    return;
+  }
+
+  const emptyParagraph = schema.nodes.paragraph.create();
+  let cursorPos: number;
+
+  if (parent.content.size === 0) {
+    const start = $from.before();
+    const end = $from.after();
+    tr.replaceWith(start, end, [imageNode, emptyParagraph]);
+    cursorPos = start + imageNode.nodeSize + 1;
+  } else {
+    const insertPos = $from.after();
+    tr.insert(insertPos, [imageNode, emptyParagraph]);
+    cursorPos = insertPos + imageNode.nodeSize + 1;
+  }
+
+  tr.setSelection(TextSelection.create(tr.doc, cursorPos));
+  view.dispatch(tr.scrollIntoView());
 };
 
 const updateImageSrc = (

--- a/components/ui-elements/editors/extensions/tasks/paste-tasks.ts
+++ b/components/ui-elements/editors/extensions/tasks/paste-tasks.ts
@@ -1,0 +1,150 @@
+import { Extension } from "@tiptap/core";
+import {
+  Fragment,
+  Node as ProseMirrorNode,
+  Schema,
+  Slice,
+} from "@tiptap/pm/model";
+import { Plugin, PluginKey } from "@tiptap/pm/state";
+
+const TASK_PREFIX_REGEX = /^\s*\[([ xX]?)\]\s+/;
+
+const stripTaskPrefix = (
+  paragraph: ProseMirrorNode,
+  schema: Schema
+): ProseMirrorNode => {
+  const children: ProseMirrorNode[] = [];
+  let prefixRemoved = false;
+
+  paragraph.content.forEach((child) => {
+    if (prefixRemoved || !child.isText || !child.text) {
+      children.push(child);
+      return;
+    }
+    const match = child.text.match(TASK_PREFIX_REGEX);
+    if (!match) {
+      children.push(child);
+      return;
+    }
+    prefixRemoved = true;
+    const newText = child.text.slice(match[0].length);
+    if (newText.length > 0) children.push(schema.text(newText, child.marks));
+  });
+
+  return paragraph.copy(Fragment.from(children));
+};
+
+const getFirstParagraphText = (listItem: ProseMirrorNode): string | null => {
+  const firstChild = listItem.firstChild;
+  if (!firstChild || firstChild.type.name !== "paragraph") return null;
+  return firstChild.textContent;
+};
+
+const areAllItemsTasks = (
+  bulletList: ProseMirrorNode,
+  listItemType: string
+): boolean => {
+  if (bulletList.childCount === 0) return false;
+  let allTasks = true;
+  bulletList.forEach((child) => {
+    if (child.type.name !== listItemType) {
+      allTasks = false;
+      return;
+    }
+    const text = getFirstParagraphText(child);
+    if (text === null || !TASK_PREFIX_REGEX.test(text)) allTasks = false;
+  });
+  return allTasks;
+};
+
+const convertListItemToTaskItem = (
+  listItem: ProseMirrorNode,
+  schema: Schema
+): ProseMirrorNode | null => {
+  const taskItemType = schema.nodes.taskItem;
+  if (!taskItemType) return null;
+
+  const firstChild = listItem.firstChild;
+  if (!firstChild || firstChild.type.name !== "paragraph") return null;
+
+  const text = firstChild.textContent;
+  const match = text.match(TASK_PREFIX_REGEX);
+  if (!match) return null;
+  const checked = match[1] === "x" || match[1] === "X";
+
+  const newChildren: ProseMirrorNode[] = [];
+  let prefixStripped = false;
+  listItem.content.forEach((child) => {
+    if (!prefixStripped && child.type.name === "paragraph") {
+      newChildren.push(stripTaskPrefix(child, schema));
+      prefixStripped = true;
+      return;
+    }
+    newChildren.push(child);
+  });
+
+  return taskItemType.create({ checked }, Fragment.from(newChildren));
+};
+
+const transformFragment = (fragment: Fragment, schema: Schema): Fragment => {
+  const bulletListType = schema.nodes.bulletList;
+  const taskListType = schema.nodes.taskList;
+  const listItemTypeName = schema.nodes.listItem?.name ?? "listItem";
+
+  const newChildren: ProseMirrorNode[] = [];
+
+  fragment.forEach((node) => {
+    if (
+      bulletListType &&
+      taskListType &&
+      node.type === bulletListType &&
+      areAllItemsTasks(node, listItemTypeName)
+    ) {
+      const taskItems: ProseMirrorNode[] = [];
+      let conversionSucceeded = true;
+      node.forEach((listItem) => {
+        const taskItem = convertListItemToTaskItem(listItem, schema);
+        if (!taskItem) {
+          conversionSucceeded = false;
+          return;
+        }
+        taskItems.push(taskItem);
+      });
+      if (conversionSucceeded && taskItems.length > 0) {
+        newChildren.push(taskListType.create(null, Fragment.from(taskItems)));
+        return;
+      }
+    }
+
+    if (node.content.size === 0) {
+      newChildren.push(node);
+      return;
+    }
+    const transformedContent = transformFragment(node.content, schema);
+    newChildren.push(node.copy(transformedContent));
+  });
+
+  return Fragment.from(newChildren);
+};
+
+export const PasteTasks = Extension.create({
+  name: "pasteTasks",
+
+  addProseMirrorPlugins() {
+    const { schema } = this.editor;
+    if (!schema.nodes.taskList || !schema.nodes.taskItem) return [];
+    if (!schema.nodes.bulletList || !schema.nodes.listItem) return [];
+
+    return [
+      new Plugin({
+        key: new PluginKey("pasteTasks"),
+        props: {
+          transformPasted: (slice) => {
+            const newContent = transformFragment(slice.content, schema);
+            return new Slice(newContent, slice.openStart, slice.openEnd);
+          },
+        },
+      }),
+    ];
+  },
+});

--- a/components/ui-elements/editors/inbox-editor/useExtensions.ts
+++ b/components/ui-elements/editors/inbox-editor/useExtensions.ts
@@ -13,6 +13,7 @@ import StarterKit from "@tiptap/starter-kit";
 import { useMemo } from "react";
 import HeadingCustom from "../extensions/heading/heading";
 import LinkBubbleMenuHandler from "../extensions/link-bubble-menu/LinkBubbleMenuHandler";
+import { PasteTasks } from "../extensions/tasks/paste-tasks";
 
 const useExtensions = (placeholder: string): EditorOptions["extensions"] => {
   const extensions = useMemo(() => {
@@ -30,6 +31,7 @@ const useExtensions = (placeholder: string): EditorOptions["extensions"] => {
           class: "flex items-start gap-2 font-semibold list-none",
         },
       }),
+      PasteTasks,
       Highlight,
       Link.extend({ inclusive: false }).configure({
         openOnClick: false,

--- a/components/ui-elements/editors/notes-editor/useExtensions.ts
+++ b/components/ui-elements/editors/notes-editor/useExtensions.ts
@@ -17,6 +17,7 @@ import { useMemo } from "react";
 import HeadingCustom from "../extensions/heading/heading";
 import LinkBubbleMenuHandler from "../extensions/link-bubble-menu/LinkBubbleMenuHandler";
 import S3ImageExtension from "../extensions/s3-images/S3ImageExtension";
+import { PasteTasks } from "../extensions/tasks/paste-tasks";
 import { TaskItem } from "../extensions/tasks/task-item";
 
 const extendedConfig: Partial<NodeConfig<any, any>> = {
@@ -68,6 +69,7 @@ const useExtensions = (): EditorOptions["extensions"] => {
           class: "flex items-start gap-2 font-semibold list-none",
         },
       }),
+      PasteTasks,
       Highlight,
       Link.extend({ inclusive: false }).configure({
         openOnClick: false,


### PR DESCRIPTION
## Summary

- **Image paste**: A pasted image now lands on its own line directly after the current block (instead of leaving empty paragraphs around it), the cursor moves into a fresh paragraph below the image, and the view scrolls to keep the cursor visible — including a second scroll once the image has finished loading so layout shifts do not hide it. Manual user scrolling (wheel/touch) cancels the deferred scroll so freshly loaded images do not yank the viewport back.
- **Task list paste**: Pasting a bullet list whose items all start with `[ ]`, `[x]`, `[X]` or `[]` is now converted into a `taskList` with the correct checked state and the prefix stripped — matching the behavior of typing `[]` directly in the editor. Wired into both the notes editor and the inbox editor.

## Test plan

- [x] Paste an image into an empty paragraph after a heading → image replaces the empty line, cursor sits in a new empty paragraph below the image, view scrolls to it.
- [x] Paste an image at the end of a non-empty paragraph → image appears on the next line, cursor in a new paragraph below.
- [x] Paste a large image that takes a moment to load → cursor stays visible after the image finishes loading.
- [x] Scroll the editor manually right after pasting an image → no jump back to the cursor once the image loads.
- [x] Open an existing note with multiple images → no unexpected scrolling while images stream in.
- [x] Paste a markdown bullet list of `- [ ] …` tasks → rendered as a task list with empty checkboxes, prefix stripped.
- [x] Paste a bullet list mixing `- [x]` and `- [ ]` items → all rendered as task items with correct checked states.
- [x] Paste a regular bullet list with no `[ ]` prefixes → remains a normal bullet list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)